### PR TITLE
accept 200 OK and 201 CREATED

### DIFF
--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/PutCommand.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/PutCommand.java
@@ -109,7 +109,7 @@ public class PutCommand<T> extends AbstractBaseClient implements ICommand<T, T>
                 }
             }
 
-            if (!service.getStatus().equals(Status.SUCCESS_CREATED))
+            if (!service.getStatus().equals(Status.SUCCESS_CREATED) && !service.getStatus().equals(Status.SUCCESS_OK))
             {
                 LOGGER.error("Unexpected HTTP status code returned: {}", service.getStatus().getCode());
 


### PR DESCRIPTION
Shouldn't break anything: Accepting both **201** and **200** success responses, will just produce debug log output and return the original response.

Without accepting **200** an ServiceException would be thrown although the original JSON response is perfectly fine:

```
{
    "code":1,
    "message":"urn:my-cool-new-object:12512215"
}
```

However, exception code and message would be the correct response. So actually no error log output or exception should be created here.
