### PR TITLE
Remove 'urn:uuid:' from RegistrationResponse.urn because it was dupli…

### DIFF
--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/common/registration/RegistrationResponse.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/common/registration/RegistrationResponse.java
@@ -38,7 +38,7 @@ public class RegistrationResponse
 
     public RegistrationResponse(JSONObject jsonObject) throws JSONException
     {
-        this.urn = "urn:uuid:" + jsonObject.getString(Field.URN_FIELD);
+        this.urn = jsonObject.getString(Field.URN_FIELD);
         this.realm = jsonObject.getString(Field.REALM_FIELD);
         this.emailAddress = jsonObject.getString(Field.EMAIL_ADDRESS_FIELD);
         this.lastModifiedTimestamp = jsonObject.getLong(Field.LAST_MODIFIED_TIMESTAMP_FIELD);


### PR DESCRIPTION
…cated (e.g., urn:uuid:urn:uuid:11e566a1-b304-01b4-8305-d3d0a645bbca)