### PR TITLE
use more verbose var names. Renamed validate to parse. Return dynamic…

### DIFF
--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
@@ -9,9 +9,9 @@ package net.smartcosmos.platform.jpa.base;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceNamedObjectEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceNamedObjectEntity.java
@@ -9,9 +9,9 @@ package net.smartcosmos.platform.jpa.base;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.


### PR DESCRIPTION
… type so that no type cast is needed anymore.