### PR TITLE
Bugfix/bindable entity reference types

### DIFF
--- a/smartcosmos-core/src/main/java/net/smartcosmos/model/base/EntityReferenceType.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/model/base/EntityReferenceType.java
@@ -20,6 +20,9 @@ package net.smartcosmos.model.base;
  * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
  */
 
+import java.util.Arrays;
+import java.util.List;
+
 /**
  * Represents a specific type of platform entity in a generic operation. Instead of defining many different
  * entity specific operations, a singular operation is typically defined by the platform where one of the
@@ -58,6 +61,42 @@ public enum EntityReferenceType
     LibraryElement,
 
     Event;
+
+    public static final List<EntityReferenceType> RELATIONSHIP_BINDABLE_ENTITY_TYPES = Arrays.asList(
+            Object,
+            ObjectAddress,
+            ObjectInteraction,
+            ObjectInteractionSession,
+            Georectification,
+            Device,
+            File,
+            Timeline,
+            LibraryElement
+    );
+
+    public static final List<EntityReferenceType> VISITOR_BINDABLE_ENTITY_TYPES = Arrays.asList(
+            Device,
+            Event,
+            File,
+            Georectification,
+            Metadata,
+            Relationship,
+            Object,
+            ObjectAddress,
+            ObjectInteraction,
+            ObjectInteractionSession,
+            Tag,
+            Timeline);
+
+    public static boolean isRelationshipBindable(EntityReferenceType referenceType)
+    {
+        return RELATIONSHIP_BINDABLE_ENTITY_TYPES.contains(referenceType);
+    }
+
+    public static boolean isVisitorBindable(EntityReferenceType referenceType)
+    {
+        return VISITOR_BINDABLE_ENTITY_TYPES.contains(referenceType);
+    }
     
     public static final boolean isValid(String referenceType)
     {

--- a/smartcosmos-core/src/main/java/net/smartcosmos/util/json/JsonUtil.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/util/json/JsonUtil.java
@@ -28,7 +28,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import net.smartcosmos.Field;
 import net.smartcosmos.model.event.IEvent;
-import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.slf4j.Logger;
@@ -96,8 +95,7 @@ public final class JsonUtil
 
     public static JSONObject translateEvent(IEvent event) throws JSONException
     {
-        JSONObject curEvent = new JSONObject()
-                .put(Field.URN_FIELD, event.getUrn())
+        JSONObject curEvent = new JSONObject().put(Field.URN_FIELD, event.getUrn())
                 .put(Field.EVENT_TYPE, event.getEventType())
                 .put(Field.LAST_MODIFIED_TIMESTAMP_FIELD, event.getLastModifiedTimestamp());
 
@@ -177,18 +175,13 @@ public final class JsonUtil
 
     public static Boolean isValidJson(String test)
     {
+        ObjectMapper objectMapper = new ObjectMapper();
         try
         {
-            new JSONObject(test);
-        } catch (JSONException e)
+            objectMapper.readTree(test);
+        } catch (IOException e)
         {
-            try
-            {
-                new JSONArray(test);
-            } catch (JSONException e1)
-            {
-                return false;
-            }
+            return false;
         }
         return true;
     }

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractVisitor.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractVisitor.java
@@ -36,7 +36,7 @@ public abstract class AbstractVisitor<T> extends AbstractService implements IVis
     /**
      * Only those EntityReferenceType values in the list below can be bound as a visitable entity.
      */
-    protected static final List<EntityReferenceType> BINDABLE_ENTITIES = Arrays.asList(
+    protected static final List<EntityReferenceType> VISITOR_BINDABLE_ENTITIES = Arrays.asList(
             EntityReferenceType.Device,
             EntityReferenceType.Event,
             EntityReferenceType.File,
@@ -75,7 +75,7 @@ public abstract class AbstractVisitor<T> extends AbstractService implements IVis
         this.priority = (priority * 4096) + uniquePriority;
 
         Preconditions.checkNotNull(entityReferenceType, "entityReferenceType must not be null");
-        Preconditions.checkArgument(BINDABLE_ENTITIES.contains(entityReferenceType),
+        Preconditions.checkArgument(VISITOR_BINDABLE_ENTITIES.contains(entityReferenceType),
                 "Specified entityReferenceType is not bindable as a visitor");
         this.entityReferenceType = entityReferenceType;
     }

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
@@ -51,8 +51,8 @@ public abstract class DomainResourceEntity<T extends IDomainResource<T>>
      */
     private static final long serialVersionUID = 1L;
 
-    public static final Integer UUID_LENGTH = 16;
-    private static final Integer MONIKER_LENGTH = 2048;
+    public static final int UUID_LENGTH = 16;
+    private static final int MONIKER_LENGTH = 2048;
 
     @Column(length = UUID_LENGTH, nullable = false, updatable = false, unique = true)
     @Type(type = "uuid-binary")

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
@@ -52,7 +52,7 @@ public abstract class DomainResourceEntity<T extends IDomainResource<T>>
     private static final long serialVersionUID = 1L;
 
     public static final int UUID_LENGTH = 16;
-    private static final int MONIKER_LENGTH = 2048;
+    public static final int MONIKER_LENGTH = 2048;
 
     @Column(length = UUID_LENGTH, nullable = false, updatable = false, unique = true)
     @Type(type = "uuid-binary")

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
@@ -51,7 +51,10 @@ public abstract class DomainResourceEntity<T extends IDomainResource<T>>
      */
     private static final long serialVersionUID = 1L;
 
-    @Column(length = 16, nullable = false, updatable = false, unique = true)
+    protected static final Integer uuidLength = 16;
+    private static final Integer monikerLength = 2048;
+
+    @Column(length = uuidLength, nullable = false, updatable = false, unique = true)
     @Type(type = "uuid-binary")
     @Id
     @JsonIgnore
@@ -62,8 +65,8 @@ public abstract class DomainResourceEntity<T extends IDomainResource<T>>
     private long lastModifiedTimestamp;
 
     @JsonView(JsonGenerationView.Full.class)
-    @Column(length = 2048, nullable = true, updatable = true)
-    @Size(max = 2048)
+    @Column(length = monikerLength, nullable = true, updatable = true)
+    @Size(max = monikerLength)
     private String moniker;
 
     @Override

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
@@ -51,10 +51,10 @@ public abstract class DomainResourceEntity<T extends IDomainResource<T>>
      */
     private static final long serialVersionUID = 1L;
 
-    protected static final Integer uuidLength = 16;
-    private static final Integer monikerLength = 2048;
+    public static final Integer UUID_LENGTH = 16;
+    private static final Integer MONIKER_LENGTH = 2048;
 
-    @Column(length = uuidLength, nullable = false, updatable = false, unique = true)
+    @Column(length = UUID_LENGTH, nullable = false, updatable = false, unique = true)
     @Type(type = "uuid-binary")
     @Id
     @JsonIgnore
@@ -65,8 +65,8 @@ public abstract class DomainResourceEntity<T extends IDomainResource<T>>
     private long lastModifiedTimestamp;
 
     @JsonView(JsonGenerationView.Full.class)
-    @Column(length = monikerLength, nullable = true, updatable = true)
-    @Size(max = monikerLength)
+    @Column(length = MONIKER_LENGTH, nullable = true, updatable = true)
+    @Size(max = MONIKER_LENGTH)
     private String moniker;
 
     @Override

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceReferentialObjectEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceReferentialObjectEntity.java
@@ -53,7 +53,7 @@ public abstract class DomainResourceReferentialObjectEntity<T extends IAccountDo
     @NotNull
     private EntityReferenceType entityReferenceType;
 
-    @Column(length = uuidLength, nullable = false, updatable = false)
+    @Column(length = UUID_LENGTH, nullable = false, updatable = false)
     @Index(name = "entity_reference_urn_idx")
     @Type(type = "uuid-binary")
     @JsonIgnore

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceReferentialObjectEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceReferentialObjectEntity.java
@@ -53,7 +53,7 @@ public abstract class DomainResourceReferentialObjectEntity<T extends IAccountDo
     @NotNull
     private EntityReferenceType entityReferenceType;
 
-    @Column(length = 16, nullable = false, updatable = false)
+    @Column(length = uuidLength, nullable = false, updatable = false)
     @Index(name = "entity_reference_urn_idx")
     @Type(type = "uuid-binary")
     @JsonIgnore

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceReferentialObjectEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceReferentialObjectEntity.java
@@ -34,6 +34,7 @@ import javax.persistence.Column;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.MappedSuperclass;
+import javax.validation.constraints.NotNull;
 import java.util.UUID;
 
 @MappedSuperclass
@@ -49,6 +50,7 @@ public abstract class DomainResourceReferentialObjectEntity<T extends IAccountDo
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, updatable = false)
     @Index(name = "entity_reference_type_idx")
+    @NotNull
     private EntityReferenceType entityReferenceType;
 
     @Column(length = 16, nullable = false, updatable = false)

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
@@ -169,7 +169,7 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
     }
 
     /**
-     * Validates an input and maps it to the corresponding domain resource entity.
+     * Parses an domain resource entity from the JSON input but does not validate it.
      *
      * @param jsonString        the json input
      * @param targetEntityClass the class used for mapping and validation
@@ -297,6 +297,13 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
         return mapper.readValue(jsonString, targetEntityClass);
     }
 
+    /**
+     * Validates a domain resource entity.
+     *
+     * @param entity the domain resource entity for validation
+     * @param <ENTITY> the sub-type of DomainResourceEntity
+     * @throws WebApplicationException
+     */
     public <ENTITY extends DomainResourceEntity> void validate(ENTITY entity) throws WebApplicationException
     {
         Validator validator = Validation.buildDefaultValidatorFactory().getValidator();

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
@@ -182,17 +182,22 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
      *
      * @param jsonString the json input
      * @param targetEntityClass the class used for mapping and validation
+     * @param performValidation if set to true, the domain resource entity will be validated
      * @return returns the validated domain resource
-     * @throws JsonProcessingException
+     * @throws WebApplicationException
      */
-    public <T extends DomainResourceEntity> T parse(String jsonString, Class<T> targetEntityClass) throws WebApplicationException
+    public <T extends DomainResourceEntity> T parse(String jsonString, Class<T> targetEntityClass, Boolean performValidation) throws
+            WebApplicationException
     {
         T entity = null;
         Response response = null;
         try
         {
             entity = jsonToEntity(jsonString, targetEntityClass);
-            validate(entity);
+            if (performValidation)
+            {
+                validate(entity);
+            }
         } catch (IOException e)
         {
             LOG.warn(e.getMessage());
@@ -210,6 +215,19 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
         }
 
         return entity;
+    }
+
+    /**
+     * Validates an input and maps it to the corresponding domain resource entity.
+     *
+     * @param jsonString the json input
+     * @param targetEntityClass the class used for mapping and validation
+     * @return returns the validated domain resource
+     * @throws WebApplicationException
+     */
+    public <T extends DomainResourceEntity> T parse(String jsonString, Class<T> targetEntityClass) throws WebApplicationException
+    {
+        return parse(jsonString, targetEntityClass, true);
     }
 
     @VisibleForTesting
@@ -298,9 +316,7 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
     private <T extends DomainResourceEntity> T jsonToEntity(String jsonString, Class<T> targetEntityClass) throws IOException
     {
         ObjectMapper mapper = createObjectMapper();
-        T entity = mapper.readValue(jsonString, targetEntityClass);
-
-        return entity;
+        return mapper.readValue(jsonString, targetEntityClass);
     }
 
     public <T extends DomainResourceEntity> void validate(T entity) throws ConstraintViolationException
@@ -324,5 +340,4 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
             throw new ConstraintViolationException(invalidFieldString, violations);
         }
     }
-
 }

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
@@ -9,9 +9,9 @@ package net.smartcosmos.platform.resource;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- *
+ * 
  *      http://www.apache.org/licenses/LICENSE-2.0
- *
+ * 
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -178,7 +178,8 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
      * @return returns the validated domain resource
      * @throws WebApplicationException
      */
-    public <ENTITY extends DomainResourceEntity> ENTITY parse(String jsonString, Class<ENTITY> targetEntityClass) throws WebApplicationException
+    public <ENTITY extends DomainResourceEntity> ENTITY parse(String jsonString, Class<ENTITY> targetEntityClass, boolean performValidation) throws
+            WebApplicationException
     {
         ENTITY entity = null;
         Response response = null;


### PR DESCRIPTION
**Changes**:
- Moved bindable entity types for relationships and visitors to `EntityReferenceType.java`
- Improved JSON syntax check in `JsonUtil.java` (before it accepted incorrect Syntax due to very relaxed constructors of in `org.json` - now Jackson is used)
- Added constraint annotation for `entityReferenceType`
- Validation in `AbstractRequestHandler` can be disabled by a `boolean` flag for downstream validation after further preparations following the parsing

*These changes are required for Relationship bugfixes.*