### PR TITLE
Feature/objects 511 validation

### DIFF
--- a/smartcosmos-core/src/main/java/net/smartcosmos/model/base/IDomainResource.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/model/base/IDomainResource.java
@@ -28,5 +28,8 @@ package net.smartcosmos.model.base;
  */
 public interface IDomainResource<T> extends IUrnNamespace, IMoniker
 {
+    int UUID_LENGTH = 16;
+    int MONIKER_LENGTH = 2048;
+
     void copy(T object);
 }

--- a/smartcosmos-core/src/main/java/net/smartcosmos/model/base/INamedObject.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/model/base/INamedObject.java
@@ -28,8 +28,8 @@ package net.smartcosmos.model.base;
  */
 public interface INamedObject<T> extends IDomainResource<T>
 {
-    int NAME_LENGTH = 255;
-    int DESCRIPTION_LENGTH = 1024;
+    int NAME_MAX_LENGTH = 255;
+    int DESCRIPTION_MAX_LENGTH = 1024;
 
     String getName();
 

--- a/smartcosmos-core/src/main/java/net/smartcosmos/model/base/INamedObject.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/model/base/INamedObject.java
@@ -28,6 +28,9 @@ package net.smartcosmos.model.base;
  */
 public interface INamedObject<T> extends IDomainResource<T>
 {
+    int NAME_LENGTH = 255;
+    int DESCRIPTION_LENGTH = 1024;
+
     String getName();
 
     void setName(String name);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/model/base/ITypedObject.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/model/base/ITypedObject.java
@@ -31,7 +31,7 @@ package net.smartcosmos.model.base;
  */
 public interface ITypedObject
 {
-    int TYPE_LENGTH = 255;
+    int TYPE_MAX_LENGTH = 255;
 
     String getType();
 

--- a/smartcosmos-core/src/main/java/net/smartcosmos/model/base/ITypedObject.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/model/base/ITypedObject.java
@@ -31,6 +31,8 @@ package net.smartcosmos.model.base;
  */
 public interface ITypedObject
 {
+    int TYPE_LENGTH = 255;
+
     String getType();
 
     void setType(String type);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/model/context/IMetadata.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/model/context/IMetadata.java
@@ -36,6 +36,9 @@ import org.json.JSONException;
  */
 public interface IMetadata extends IAccountDomainResource<IMetadata>, IReferentialObject
 {
+    int KEY_MAX_LENGTH = 255;
+    int RAW_VALUE_MAX_LENGTH = 767;
+
     MetadataDataType getDataType();
 
     void setDataType(MetadataDataType type);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/model/context/IUser.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/model/context/IUser.java
@@ -31,6 +31,10 @@ import net.smartcosmos.model.base.IAccountDomainResource;
  */
 public interface IUser extends IAccountDomainResource<IUser>
 {
+    int EMAIL_ADDRESS_MAX_LENGTH = 128;
+    int GIVEN_NAME_MAX_LENGTH = 50;
+    int SURNAME_MAX_LENGTH = 50;
+
     String getGivenName();
 
     void setGivenName(String givenName);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/model/event/IEvent.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/model/event/IEvent.java
@@ -32,6 +32,9 @@ import net.smartcosmos.model.context.IUser;
  */
 public interface IEvent extends IAccountDomainResource<IEvent>
 {
+    int SOURCE_MAX_LENGTH = 8192;
+    int USER_DEFINITION_MAX_LENGTH = 8192;
+
     EventType getEventType();
 
     void setEventType(EventType eventType);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/model/extension/IExternalExtension.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/model/extension/IExternalExtension.java
@@ -33,6 +33,14 @@ import net.smartcosmos.model.context.IAccount;
  */
 public interface IExternalExtension extends IDomainResource<IExternalExtension>, INamedObject<IExternalExtension>
 {
+    int SUPPORT_EMAIL_MAX_LENGTH = 128;
+    int WEBSITE_URL_MAX_LENGTH = 1024;
+    int CLIENT_ID_MAX_LENGTH = 48;
+    int CLIENT_SECRET_MAX_LENGTH = 48;
+    int REDIRECT_URL_MAX_LENGTH = 1024;
+    int APP_CATALOG_URL_MAX_LENGTH = 1024;
+    int LONG_DESCRIPTION_MAX_LENGTH = 1024;
+
     int getVersion();
 
     void setVersion(int version);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/model/geo/IGeospatialEntry.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/model/geo/IGeospatialEntry.java
@@ -60,6 +60,8 @@ import net.smartcosmos.model.base.ITypedObject;
 public interface IGeospatialEntry
         extends IAccountDomainResource<IGeospatialEntry>, INamedObject<IGeospatialEntry>, ITypedObject
 {
+    int GEO_JSON_MAX_LENGTH = 8192;
+
     GeometricShape getGeometricShape();
 
     void setGeometricShape(GeometricShape geometricShape);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/model/integration/INotificationEndpoint.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/model/integration/INotificationEndpoint.java
@@ -33,6 +33,11 @@ import net.smartcosmos.model.context.IAccount;
 public interface INotificationEndpoint
         extends IAccountDomainResource<INotificationEndpoint>, INamedObject<INotificationEndpoint>, IReferentialObject
 {
+    int ENCODED_PUBLIC_KEY_MAX_LENGTH = 1024;
+    int ENCODED_PRIVATE_KEY_MAX_LENGTH = 1024;
+    int TOPIC_ARN_MAX_LENGTH = 1024;
+    int SUBSCRIPTION_ARN_MAX_LENGTH = 1024;
+    int NOTIFICATION_ENDPOINT_URL_MAX_LENGTH = 1024;
 
     IAccount getReferenceAccount();
 

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/model/context/IDevice.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/model/context/IDevice.java
@@ -35,6 +35,8 @@ import net.smartcosmos.model.base.ITypedObject;
  */
 public interface IDevice extends IAccountDomainResource<IDevice>, INamedObject<IDevice>, ITypedObject
 {
+    int IDENTIFICATION_LENGTH = 256;
+
     String getIdentification();
 
     void setIdentification(String identification);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/model/context/IFile.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/model/context/IFile.java
@@ -32,6 +32,11 @@ import net.smartcosmos.model.base.IReferentialObject;
  */
 public interface IFile extends IAccountDomainResource<IFile>, IReferentialObject
 {
+    int URL_MAX_LENGTH = 2048;
+    int FILE_NAME_MAX_LENGTH = 2048;
+    int MIME_TYPE_MAX_LENGTH = 100;
+    int DIGITAL_SIGNATURE_MAX_LENGTH = 1024;
+
     long getTimestamp();
 
     void setTimestamp(long timestamp);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/model/context/IObject.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/model/context/IObject.java
@@ -40,6 +40,8 @@ import net.smartcosmos.model.base.ITypedObject;
  */
 public interface IObject extends IAccountDomainResource<IObject>, INamedObject<IObject>, ITypedObject
 {
+    int OBJECT_URN_LENGTH = 767;
+
     String getObjectUrn();
 
     void setObjectUrn(String urn);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/model/context/IObjectAddress.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/model/context/IObjectAddress.java
@@ -30,6 +30,13 @@ import net.smartcosmos.model.base.ITypedObject;
  */
 public interface IObjectAddress extends IAccountDomainResource<IObjectAddress>, ITypedObject
 {
+    int LINE_1_MAX_LENGTH = 1024;
+    int LINE_2_MAX_LENGTH = 1024;
+    int CITY_MAX_LENGTH = 1024;
+    int STATE_PROVINCE_MAX_LENGTH = 50;
+    int POSTAL_CODE_MAX_LENGTH = 20;
+    int COUNTRY_ABBREVIATION_MAX_LENGTH = 2;
+
     IObject getObject();
 
     void setObject(IObject object);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/Device.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/Device.java
@@ -25,9 +25,14 @@ import net.smartcosmos.objects.model.context.IDevice;
 import net.smartcosmos.pojo.base.AccountTypedNamedObject;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 public class Device extends AccountTypedNamedObject<IDevice> implements IDevice
 {
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
+    @Size(max = IDENTIFICATION_LENGTH)
     protected String identification;
 
     @Override
@@ -61,8 +66,8 @@ public class Device extends AccountTypedNamedObject<IDevice> implements IDevice
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + type.hashCode();
-        result = 31 * result + identification.hashCode();
+        result = 31 * result + ((type == null) ? 0 : type.hashCode());
+        result = 31 * result + ((identification == null) ? 0 : identification.hashCode());
         return result;
     }
 }

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/File.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/File.java
@@ -25,12 +25,18 @@ import net.smartcosmos.objects.model.context.IFile;
 import net.smartcosmos.pojo.base.ReferentialObject;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 public class File extends ReferentialObject<IFile> implements IFile
 {
     @JsonView(JsonGenerationView.Restricted.class)
+    @Size(max = URL_MAX_LENGTH)
     protected String url;
 
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
+    @Size(max = MIME_TYPE_MAX_LENGTH)
     protected String mimeType;
 
     @JsonView(JsonGenerationView.Standard.class)
@@ -40,9 +46,11 @@ public class File extends ReferentialObject<IFile> implements IFile
     protected boolean pending;
 
     @JsonView(JsonGenerationView.Full.class)
+    @Size(max = DIGITAL_SIGNATURE_MAX_LENGTH)
     protected String digitalSignature;
 
     @JsonView(JsonGenerationView.Standard.class)
+    @Size(max = FILE_NAME_MAX_LENGTH)
     protected String fileName;
 
     @Override

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/LibraryElement.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/LibraryElement.java
@@ -34,7 +34,7 @@ public class LibraryElement extends AccountTypedNamedObject<ILibraryElement> imp
 {
     @JsonView(JsonGenerationView.Minimum.class)
     @NotNull
-    @Size(max = TYPE_LENGTH)
+    @Size(max = TYPE_MAX_LENGTH)
     private String libraryElementType;
 
     @JsonView(JsonGenerationView.Minimum.class)

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/LibraryElement.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/LibraryElement.java
@@ -25,14 +25,21 @@ import net.smartcosmos.objects.model.context.ILibraryElement;
 import net.smartcosmos.pojo.base.AccountTypedNamedObject;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 import static net.smartcosmos.Field.LIBRARY_ELEMENT_TYPE_NAME;
 
 public class LibraryElement extends AccountTypedNamedObject<ILibraryElement> implements ILibraryElement
 {
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
+    @Size(max = TYPE_LENGTH)
     private String libraryElementType;
 
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
+    @Size(max = UUID_LENGTH)
     private String parent;
 
     public String getLibraryElementType()

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/ObjectAddress.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/ObjectAddress.java
@@ -41,27 +41,27 @@ public class ObjectAddress extends AccountDomainResource<IObjectAddress> impleme
     protected String type;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    @Size(max = 1024)
+    @Size(max = LINE_1_MAX_LENGTH)
     private String line1;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    @Size(max = 1024)
+    @Size(max = LINE_2_MAX_LENGTH)
     private String line2;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    @Size(max = 1024)
+    @Size(max = CITY_MAX_LENGTH)
     private String city;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    @Size(max = 50)
+    @Size(max = STATE_PROVINCE_MAX_LENGTH)
     private String stateProvince;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    @Size(max = 20)
+    @Size(max = POSTAL_CODE_MAX_LENGTH)
     private String postalCode;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    @Size(max = 2)
+    @Size(max = COUNTRY_ABBREVIATION_MAX_LENGTH)
     private String countryAbbreviation;
 
     @JsonView(JsonGenerationView.Standard.class)
@@ -225,8 +225,8 @@ public class ObjectAddress extends AccountDomainResource<IObjectAddress> impleme
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + object.hashCode();
-        result = 31 * result + type.hashCode();
+        result = 31 * result + (object != null ? object.hashCode() : 0);
+        result = 31 * result + (type != null ? type.hashCode() : 0);
         result = 31 * result + (line1 != null ? line1.hashCode() : 0);
         result = 31 * result + (line2 != null ? line2.hashCode() : 0);
         result = 31 * result + (city != null ? city.hashCode() : 0);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/ObjectImpl.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/ObjectImpl.java
@@ -25,9 +25,14 @@ import net.smartcosmos.objects.model.context.IObject;
 import net.smartcosmos.pojo.base.AccountTypedNamedObject;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 public class ObjectImpl extends AccountTypedNamedObject<IObject> implements IObject
 {
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
+    @Size(max = OBJECT_URN_LENGTH)
     protected String objectUrn;
 
     @Override

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/ObjectInteraction.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/ObjectInteraction.java
@@ -31,6 +31,9 @@ import net.smartcosmos.pojo.base.ReferentialObject;
 import net.smartcosmos.pojo.context.Account;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 public class ObjectInteraction extends ReferentialObject<IObjectInteraction> implements IObjectInteraction
 {
     @JsonView(JsonGenerationView.Full.class)
@@ -39,6 +42,7 @@ public class ObjectInteraction extends ReferentialObject<IObjectInteraction> imp
 
     @JsonView(JsonGenerationView.Minimum.class)
     @JsonDeserialize(as = ObjectImpl.class)
+    @NotNull
     protected IObject object;
 
     @JsonView(JsonGenerationView.Standard.class)
@@ -55,6 +59,8 @@ public class ObjectInteraction extends ReferentialObject<IObjectInteraction> imp
     protected IObjectInteractionSession objectInteractionSession;
 
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
+    @Size(max = TYPE_MAX_LENGTH)
     protected String type;
 
     @Override

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/Relationship.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/Relationship.java
@@ -112,19 +112,9 @@ public class Relationship extends ReferentialObject<IRelationship> implements IR
     {
         int result = super.hashCode();
 
-        // hashCode() is called during validation and would throw a ValidationException if hashCode() of fields can not be called:
-        if (relatedEntityReferenceType != null)
-        {
-            result = 31 * result + relatedEntityReferenceType.hashCode();
-        }
-        if (relatedReferenceUrn != null)
-        {
-            result = 31 * result + relatedReferenceUrn.hashCode();
-        }
-        if (type != null)
-        {
-            result = 31 * result + type.hashCode();
-        }
+        result = 31 * result + ((relatedEntityReferenceType == null) ? 0 : relatedEntityReferenceType.hashCode());
+        result = 31 * result + ((relatedReferenceUrn == null) ? 0 : relatedReferenceUrn.hashCode());
+        result = 31 * result + ((type == null) ? 0 : type.hashCode());
         result = 31 * result + Boolean.valueOf(reciprocal).hashCode();
         return result;
     }

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/Relationship.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/Relationship.java
@@ -27,15 +27,22 @@ import net.smartcosmos.objects.model.context.IRelationship;
 import net.smartcosmos.pojo.base.ReferentialObject;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 public class Relationship extends ReferentialObject<IRelationship> implements IRelationship
 {
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
     protected EntityReferenceType relatedEntityReferenceType;
 
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
     protected String relatedReferenceUrn;
 
     @JsonView(JsonGenerationView.Minimum.class)
+    @Size(max = TYPE_LENGTH)
+    @NotNull
     protected String type;
 
     @JsonView(JsonGenerationView.Full.class)
@@ -104,9 +111,20 @@ public class Relationship extends ReferentialObject<IRelationship> implements IR
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + relatedEntityReferenceType.hashCode();
-        result = 31 * result + relatedReferenceUrn.hashCode();
-        result = 31 * result + type.hashCode();
+
+        // hashCode() is called during validation and would throw a ValidationException if hashCode() of fields can not be called:
+        if (relatedEntityReferenceType != null)
+        {
+            result = 31 * result + relatedEntityReferenceType.hashCode();
+        }
+        if (relatedReferenceUrn != null)
+        {
+            result = 31 * result + relatedReferenceUrn.hashCode();
+        }
+        if (type != null)
+        {
+            result = 31 * result + type.hashCode();
+        }
         result = 31 * result + Boolean.valueOf(reciprocal).hashCode();
         return result;
     }

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/Relationship.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/Relationship.java
@@ -41,7 +41,7 @@ public class Relationship extends ReferentialObject<IRelationship> implements IR
     protected String relatedReferenceUrn;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    @Size(max = TYPE_LENGTH)
+    @Size(max = TYPE_MAX_LENGTH)
     @NotNull
     protected String type;
 

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/TagAssignment.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/TagAssignment.java
@@ -63,7 +63,7 @@ public class TagAssignment extends ReferentialObject<ITagAssignment> implements 
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + tag.hashCode();
+        result = 31 * result + ((tag == null) ? 0 : tag.hashCode());
         return result;
     }
 }

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/TimelineEntry.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/TimelineEntry.java
@@ -25,9 +25,14 @@ import net.smartcosmos.objects.model.context.ITimelineEntry;
 import net.smartcosmos.pojo.base.ReferentialObject;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 public class TimelineEntry extends ReferentialObject<ITimelineEntry> implements ITimelineEntry
 {
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
+    @Size(max = NAME_MAX_LENGTH)
     protected String name;
 
     @JsonView(JsonGenerationView.Standard.class)

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/AccountDomainResource.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/AccountDomainResource.java
@@ -63,7 +63,7 @@ public class AccountDomainResource <T> extends DomainResource<T> implements IAcc
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + account.hashCode();
+        result = 31 * result + (account != null ? account.hashCode() : 0);
         return result;
     }
 }

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/AccountNamedObject.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/AccountNamedObject.java
@@ -63,7 +63,7 @@ public class AccountNamedObject<T> extends NamedObject<T> implements IAccountCon
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + account.hashCode();
+        result = 31 * result + ((account == null) ? 0 : account.hashCode());
         return result;
     }
 }

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/DomainResource.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/DomainResource.java
@@ -20,6 +20,7 @@ package net.smartcosmos.pojo.base;
  * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
  */
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonView;
 import net.smartcosmos.model.base.IDomainResource;
@@ -30,6 +31,7 @@ import javax.validation.constraints.Size;
 import java.util.UUID;
 
 @JsonPropertyOrder(value = { "urn", "lastModifiedTimestamp" })
+@JsonIgnoreProperties({"returnValueType"})
 public abstract class DomainResource<T> implements IDomainResource<T>
 {
     protected UUID systemUuid;
@@ -38,7 +40,7 @@ public abstract class DomainResource<T> implements IDomainResource<T>
     protected long lastModifiedTimestamp;
 
     @JsonView(JsonGenerationView.Full.class)
-    @Size(max = 1024)
+    @Size(max = MONIKER_LENGTH)
     protected String moniker;
 
     @Override

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/NamedObject.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/NamedObject.java
@@ -30,12 +30,12 @@ import javax.validation.constraints.Size;
 public abstract class NamedObject<T> extends DomainResource<T>implements INamedObject<T>
 {
     @JsonView(JsonGenerationView.Published.class)
-    @Size(max = NAME_LENGTH)
+    @Size(max = NAME_MAX_LENGTH)
     @NotNull
     protected String name;
 
     @JsonView(JsonGenerationView.Standard.class)
-    @Size(max = DESCRIPTION_LENGTH)
+    @Size(max = DESCRIPTION_MAX_LENGTH)
     protected String description;
 
     @JsonView(JsonGenerationView.Standard.class)

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/NamedObject.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/NamedObject.java
@@ -24,12 +24,18 @@ import com.fasterxml.jackson.annotation.JsonView;
 import net.smartcosmos.model.base.INamedObject;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 public abstract class NamedObject<T> extends DomainResource<T>implements INamedObject<T>
 {
     @JsonView(JsonGenerationView.Published.class)
+    @Size(max = NAME_LENGTH)
+    @NotNull
     protected String name;
 
     @JsonView(JsonGenerationView.Standard.class)
+    @Size(max = DESCRIPTION_LENGTH)
     protected String description;
 
     @JsonView(JsonGenerationView.Standard.class)

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/TypedNamedObject.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/TypedNamedObject.java
@@ -25,12 +25,14 @@ import com.google.common.base.Preconditions;
 import net.smartcosmos.model.base.ITypedObject;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 public abstract class TypedNamedObject<T> extends NamedObject<T>implements ITypedObject
 {
     @JsonView(JsonGenerationView.Minimum.class)
-    @Size(max = 255)
+    @Size(max = TYPE_LENGTH)
+    @NotNull
     protected String type;
 
     @Override

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/TypedNamedObject.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/TypedNamedObject.java
@@ -31,7 +31,7 @@ import javax.validation.constraints.Size;
 public abstract class TypedNamedObject<T> extends NamedObject<T>implements ITypedObject
 {
     @JsonView(JsonGenerationView.Minimum.class)
-    @Size(max = TYPE_LENGTH)
+    @Size(max = TYPE_MAX_LENGTH)
     @NotNull
     protected String type;
 

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/context/Metadata.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/context/Metadata.java
@@ -37,6 +37,8 @@ import net.smartcosmos.util.mapper.StringMapper;
 import org.json.JSONException;
 import org.json.JSONObject;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.util.Date;
 
 public class Metadata extends ReferentialObject<IMetadata> implements IMetadata
@@ -180,9 +182,13 @@ public class Metadata extends ReferentialObject<IMetadata> implements IMetadata
     protected MetadataDataType dataType;
 
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
+    @Size(max = KEY_MAX_LENGTH)
     protected String key;
 
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
+    @Size(max = RAW_VALUE_MAX_LENGTH)
     protected String rawValue;
 
     @JsonView(JsonGenerationView.Full.class)

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/context/User.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/context/User.java
@@ -143,11 +143,11 @@ public class User extends DomainResource< IUser > implements IUser
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + emailAddress.hashCode();
+        result = 31 * result + ((emailAddress == null) ? 0 : emailAddress.hashCode());
         result = 31 * result + (account != null ? account.hashCode() : 0);
         result = 31 * result + (givenName != null ? givenName.hashCode() : 0);
         result = 31 * result + (surname != null ? surname.hashCode() : 0);
-        result = 31 * result + roleType.hashCode();
+        result = 31 * result + ((roleType == null) ? 0 : roleType.hashCode());
         return result;
     }
 

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/context/User.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/context/User.java
@@ -28,6 +28,9 @@ import net.smartcosmos.pojo.base.DomainResource;
 import net.smartcosmos.util.UuidUtil;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 
 public class User extends DomainResource< IUser > implements IUser
 {
@@ -36,12 +39,22 @@ public class User extends DomainResource< IUser > implements IUser
     protected IAccount account;
     @JsonView(JsonGenerationView.Minimum.class)
     protected RoleType roleType;
+
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
+    @Size(max = EMAIL_ADDRESS_MAX_LENGTH)
     private String emailAddress;
+
     @JsonView(JsonGenerationView.Full.class)
+    @NotNull
+    @Size(max = GIVEN_NAME_MAX_LENGTH)
     private String givenName;
+
     @JsonView(JsonGenerationView.Full.class)
+    @NotNull
+    @Size(max = SURNAME_MAX_LENGTH)
     private String surname;
+
     @Override
     public String getEmailAddress()
     {

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/context/User.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/context/User.java
@@ -37,6 +37,7 @@ public class User extends DomainResource< IUser > implements IUser
     @JsonView(JsonGenerationView.Full.class)
     @JsonDeserialize(as = Account.class)
     protected IAccount account;
+
     @JsonView(JsonGenerationView.Minimum.class)
     protected RoleType roleType;
 

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/event/Event.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/event/Event.java
@@ -31,10 +31,13 @@ import net.smartcosmos.pojo.context.Account;
 import net.smartcosmos.pojo.context.User;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.Size;
+
 public class Event extends DomainResource<IEvent> implements IEvent
 {
     @JsonView(JsonGenerationView.Minimum.class)
     @JsonDeserialize(as = User.class)
+    @Size(max = USER_DEFINITION_MAX_LENGTH)
     protected IUser user;
 
     @JsonView(JsonGenerationView.Restricted.class)
@@ -45,6 +48,7 @@ public class Event extends DomainResource<IEvent> implements IEvent
     protected EventType eventType;
 
     @JsonView(JsonGenerationView.Minimum.class)
+    @Size(max = SOURCE_MAX_LENGTH)
     protected String source;
 
     @JsonView(JsonGenerationView.Minimum.class)

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/extension/ExternalExtension.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/extension/ExternalExtension.java
@@ -29,6 +29,9 @@ import net.smartcosmos.pojo.base.NamedObject;
 import net.smartcosmos.pojo.context.Account;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 public class ExternalExtension extends NamedObject<IExternalExtension> implements IExternalExtension
 {
     @JsonView(JsonGenerationView.Restricted.class)
@@ -36,24 +39,36 @@ public class ExternalExtension extends NamedObject<IExternalExtension> implement
     protected IAccount account;
 
     @JsonView(JsonGenerationView.Standard.class)
+    @NotNull
+    @Size(max = SUPPORT_EMAIL_MAX_LENGTH)
     protected String supportEmail;
 
     @JsonView(JsonGenerationView.Published.class)
+    @Size(max = WEBSITE_URL_MAX_LENGTH)
     protected String webSiteUrl;
 
     @JsonView(JsonGenerationView.Full.class)
+    @NotNull
+    @Size(max = CLIENT_ID_MAX_LENGTH)
     protected String clientId;
 
     @JsonView(JsonGenerationView.Full.class)
+    @NotNull
+    @Size(max = CLIENT_SECRET_MAX_LENGTH)
     protected String clientSecret;
 
     @JsonView(JsonGenerationView.Full.class)
+    @NotNull
+    @Size(max = REDIRECT_URL_MAX_LENGTH)
     protected String redirectUrl;
 
     @JsonView(JsonGenerationView.Published.class)
+    @NotNull
+    @Size(max = APP_CATALOG_URL_MAX_LENGTH)
     protected String appCatalogUrl;
 
     @JsonView(JsonGenerationView.Standard.class)
+    @Size(max = LONG_DESCRIPTION_MAX_LENGTH)
     protected String longDescription;
 
     @JsonView(JsonGenerationView.Published.class)

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/geo/GeospatialEntry.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/geo/GeospatialEntry.java
@@ -26,9 +26,14 @@ import net.smartcosmos.model.geo.IGeospatialEntry;
 import net.smartcosmos.pojo.base.AccountTypedNamedObject;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 public class GeospatialEntry extends AccountTypedNamedObject<IGeospatialEntry> implements IGeospatialEntry
 {
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
+    @Size(max = GEO_JSON_MAX_LENGTH)
     protected GeometricShape geometricShape;
 
     @Override
@@ -61,7 +66,7 @@ public class GeospatialEntry extends AccountTypedNamedObject<IGeospatialEntry> i
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + geometricShape.hashCode();
+        result = 31 * result + ((geometricShape == null) ? 0 : geometricShape.hashCode());
         return result;
     }
 }

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/integration/NotificationEndpoint.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/integration/NotificationEndpoint.java
@@ -28,6 +28,9 @@ import net.smartcosmos.pojo.base.ReferentialObject;
 import net.smartcosmos.pojo.context.Account;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+
 /**
  * Represents an HTTP/S integration endpoint POJO that SMART COSMOS uses to push SMART COSMOS events in JSON form
  * in near real-time. These endpoints are used for back office integration and 3rd party extension integration.
@@ -36,30 +39,41 @@ public class NotificationEndpoint extends ReferentialObject<INotificationEndpoin
 {
     @JsonView(JsonGenerationView.Restricted.class)
     @JsonDeserialize(as = Account.class)
+    @NotNull
     protected IAccount referenceAccount;
 
     @JsonView(JsonGenerationView.Standard.class)
+    @NotNull
+    @Size(max = ENCODED_PUBLIC_KEY_MAX_LENGTH)
     protected String encodedPublicKey;
 
     @JsonView(JsonGenerationView.Restricted.class)
+    @NotNull
+    @Size(max = ENCODED_PRIVATE_KEY_MAX_LENGTH)
     protected String encodedPrivateKey;
 
     @JsonView(JsonGenerationView.Restricted.class)
+    @Size(max = TOPIC_ARN_MAX_LENGTH)
     protected String topicArn;
 
     @JsonView(JsonGenerationView.Restricted.class)
+    @Size(max = SUBSCRIPTION_ARN_MAX_LENGTH)
     protected String subscriptionArn;
 
     @JsonView(JsonGenerationView.Full.class)
+    @Size(max = NOTIFICATION_ENDPOINT_URL_MAX_LENGTH)
     protected String integrationEndpointUrl;
 
     @JsonView(JsonGenerationView.Full.class)
     protected boolean pendingConfirmation;
 
     @JsonView(JsonGenerationView.Published.class)
+    @NotNull
+    @Size(max = NAME_MAX_LENGTH)
     protected String name;
 
     @JsonView(JsonGenerationView.Standard.class)
+    @Size(max = DESCRIPTION_MAX_LENGTH)
     protected String description;
 
     @JsonView(JsonGenerationView.Standard.class)
@@ -201,14 +215,14 @@ public class NotificationEndpoint extends ReferentialObject<INotificationEndpoin
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + referenceAccount.hashCode();
-        result = 31 * result + encodedPublicKey.hashCode();
-        result = 31 * result + encodedPrivateKey.hashCode();
+        result = 31 * result + ((referenceAccount == null) ? 0 : referenceAccount.hashCode());
+        result = 31 * result + ((encodedPublicKey == null) ? 0 : encodedPublicKey.hashCode());
+        result = 31 * result + ((encodedPrivateKey == null) ? 0 : encodedPrivateKey.hashCode());
         result = 31 * result + (topicArn != null ? topicArn.hashCode() : 0);
         result = 31 * result + (subscriptionArn != null ? subscriptionArn.hashCode() : 0);
-        result = 31 * result + integrationEndpointUrl.hashCode();
+        result = 31 * result + ((integrationEndpointUrl == null) ? 0 : integrationEndpointUrl.hashCode());
         result = 31 * result + (pendingConfirmation ? 1 : 0);
-        result = 31 * result + name.hashCode();
+        result = 31 * result + ((name == null) ? 0 : name.hashCode());
         result = 31 * result + (description != null ? description.hashCode() : 0);
         result = 31 * result + (activeFlag ? 1 : 0);
         return result;

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/EventEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/EventEntity.java
@@ -50,7 +50,7 @@ public class EventEntity extends DomainResourceEntity<IEvent> implements IEvent
     protected EventType eventType;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    @Column(length = 8192, nullable = true, updatable = false)
+    @Column(length = USER_DEFINITION_MAX_LENGTH, nullable = true, updatable = false)
     protected String jsonUserDefinition;
 
     @JsonView(JsonGenerationView.Restricted.class)
@@ -60,7 +60,7 @@ public class EventEntity extends DomainResourceEntity<IEvent> implements IEvent
     protected IAccount account;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    @Column(length = 8192, nullable = true)
+    @Column(length = SOURCE_MAX_LENGTH, nullable = true)
     protected String source;
 
     @JsonView(JsonGenerationView.Minimum.class)

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/UserEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/UserEntity.java
@@ -38,15 +38,15 @@ public class UserEntity extends DomainResourceAccountEntity<IUser>implements IUs
     private static final long serialVersionUID = -1564031691451114125L;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    @Column(length = 128, nullable = false, updatable = false)
+    @Column(length = EMAIL_ADDRESS_MAX_LENGTH, nullable = false, updatable = false)
     protected String emailAddress;
 
     @JsonView(JsonGenerationView.Full.class)
-    @Column(length = 50, nullable = false)
+    @Column(length = GIVEN_NAME_MAX_LENGTH, nullable = false)
     protected String givenName;
 
     @JsonView(JsonGenerationView.Full.class)
-    @Column(length = 50, nullable = false)
+    @Column(length = SURNAME_MAX_LENGTH, nullable = false)
     protected String surname;
 
     @JsonView(JsonGenerationView.Minimum.class)

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
@@ -38,6 +38,7 @@ import javax.persistence.MappedSuperclass;
 import javax.persistence.PostLoad;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
+import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.UUID;
 
@@ -62,7 +63,7 @@ public abstract class DomainResourceEntity<T extends IDomainResource<T>>
 
     @JsonView(JsonGenerationView.Full.class)
     @Column(length = MONIKER_LENGTH, nullable = true, updatable = true)
-//    @Size(max = MONIKER_LENGTH)
+    @Size(max = MONIKER_LENGTH)
     private String moniker;
 
     @Override

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
@@ -38,7 +38,6 @@ import javax.persistence.MappedSuperclass;
 import javax.persistence.PostLoad;
 import javax.persistence.PrePersist;
 import javax.persistence.PreUpdate;
-import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.UUID;
 
@@ -63,7 +62,7 @@ public abstract class DomainResourceEntity<T extends IDomainResource<T>>
 
     @JsonView(JsonGenerationView.Full.class)
     @Column(length = MONIKER_LENGTH, nullable = true, updatable = true)
-    @Size(max = MONIKER_LENGTH)
+//    @Size(max = MONIKER_LENGTH)
     private String moniker;
 
     @Override

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceEntity.java
@@ -51,9 +51,6 @@ public abstract class DomainResourceEntity<T extends IDomainResource<T>>
      */
     private static final long serialVersionUID = 1L;
 
-    public static final int UUID_LENGTH = 16;
-    public static final int MONIKER_LENGTH = 2048;
-
     @Column(length = UUID_LENGTH, nullable = false, updatable = false, unique = true)
     @Type(type = "uuid-binary")
     @Id

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceNamedObjectEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceNamedObjectEntity.java
@@ -40,14 +40,14 @@ public abstract class DomainResourceNamedObjectEntity<T extends INamedObject<T>>
     private static final long serialVersionUID = 1L;
 
     @JsonView(JsonGenerationView.Published.class)
-    @Column(length = 255, nullable = false)
-    @Size(max = 255)
+    @Column(length = NAME_LENGTH, nullable = false)
+    @Size(max = NAME_LENGTH)
     @NotNull
     private String name;
 
     @JsonView(JsonGenerationView.Standard.class)
-    @Column(length = 1024)
-    @Size(max = 1024)
+    @Column(length = DESCRIPTION_LENGTH)
+    @Size(max = DESCRIPTION_LENGTH)
     private String description;
 
     @JsonView(JsonGenerationView.Standard.class)

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceNamedObjectEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceNamedObjectEntity.java
@@ -38,14 +38,14 @@ public abstract class DomainResourceNamedObjectEntity<T extends INamedObject<T>>
     private static final long serialVersionUID = 1L;
 
     @JsonView(JsonGenerationView.Published.class)
-    @Column(length = NAME_LENGTH, nullable = false)
-//    @Size(max = NAME_LENGTH)
+    @Column(length = NAME_MAX_LENGTH, nullable = false)
+//    @Size(max = NAME_MAX_LENGTH)
 //    @NotNull
     private String name;
 
     @JsonView(JsonGenerationView.Standard.class)
-    @Column(length = DESCRIPTION_LENGTH)
-//    @Size(max = DESCRIPTION_LENGTH)
+    @Column(length = DESCRIPTION_MAX_LENGTH)
+//    @Size(max = DESCRIPTION_MAX_LENGTH)
     private String description;
 
     @JsonView(JsonGenerationView.Standard.class)

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceNamedObjectEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceNamedObjectEntity.java
@@ -27,8 +27,6 @@ import net.smartcosmos.util.json.JsonGenerationView;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
-import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 
 @MappedSuperclass
 public abstract class DomainResourceNamedObjectEntity<T extends INamedObject<T>>
@@ -41,13 +39,13 @@ public abstract class DomainResourceNamedObjectEntity<T extends INamedObject<T>>
 
     @JsonView(JsonGenerationView.Published.class)
     @Column(length = NAME_LENGTH, nullable = false)
-    @Size(max = NAME_LENGTH)
-    @NotNull
+//    @Size(max = NAME_LENGTH)
+//    @NotNull
     private String name;
 
     @JsonView(JsonGenerationView.Standard.class)
     @Column(length = DESCRIPTION_LENGTH)
-    @Size(max = DESCRIPTION_LENGTH)
+//    @Size(max = DESCRIPTION_LENGTH)
     private String description;
 
     @JsonView(JsonGenerationView.Standard.class)

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceNamedObjectEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceNamedObjectEntity.java
@@ -27,6 +27,8 @@ import net.smartcosmos.util.json.JsonGenerationView;
 import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.MappedSuperclass;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 @MappedSuperclass
 public abstract class DomainResourceNamedObjectEntity<T extends INamedObject<T>>
@@ -39,13 +41,13 @@ public abstract class DomainResourceNamedObjectEntity<T extends INamedObject<T>>
 
     @JsonView(JsonGenerationView.Published.class)
     @Column(length = NAME_MAX_LENGTH, nullable = false)
-//    @Size(max = NAME_MAX_LENGTH)
-//    @NotNull
+    @Size(max = NAME_MAX_LENGTH)
+    @NotNull
     private String name;
 
     @JsonView(JsonGenerationView.Standard.class)
     @Column(length = DESCRIPTION_MAX_LENGTH)
-//    @Size(max = DESCRIPTION_MAX_LENGTH)
+    @Size(max = DESCRIPTION_MAX_LENGTH)
     private String description;
 
     @JsonView(JsonGenerationView.Standard.class)

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceReferentialObjectEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/base/DomainResourceReferentialObjectEntity.java
@@ -25,6 +25,7 @@ import com.fasterxml.jackson.annotation.JsonView;
 import net.smartcosmos.model.base.EntityReferenceType;
 import net.smartcosmos.model.base.IAccountDomainResource;
 import net.smartcosmos.model.base.IReferentialObject;
+import net.smartcosmos.pojo.base.DomainResource;
 import net.smartcosmos.util.UuidUtil;
 import net.smartcosmos.util.json.JsonGenerationView;
 import org.hibernate.annotations.Index;
@@ -53,7 +54,7 @@ public abstract class DomainResourceReferentialObjectEntity<T extends IAccountDo
     @NotNull
     private EntityReferenceType entityReferenceType;
 
-    @Column(length = UUID_LENGTH, nullable = false, updatable = false)
+    @Column(length = DomainResource.UUID_LENGTH, nullable = false, updatable = false)
     @Index(name = "entity_reference_urn_idx")
     @Type(type = "uuid-binary")
     @JsonIgnore

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
@@ -49,6 +49,7 @@ import org.slf4j.LoggerFactory;
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
 import javax.validation.Validation;
+import javax.validation.ValidationException;
 import javax.validation.Validator;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.CacheControl;
@@ -322,11 +323,18 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
     public <ENTITY extends IDomainResource> void validate(final ENTITY entity) throws WebApplicationException
     {
         Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
-        Set<ConstraintViolation<ENTITY>> violations = validator.validate(entity);
-        if (!violations.isEmpty())
+        try
         {
-            SmartCosmosConstraintViolationExceptionMapper exceptionMapper = new SmartCosmosConstraintViolationExceptionMapper();
-            throw new WebApplicationException(exceptionMapper.toResponse(new ConstraintViolationException(violations)));
+            Set<ConstraintViolation<ENTITY>> violations = validator.validate(entity);
+            if (!violations.isEmpty())
+            {
+                SmartCosmosConstraintViolationExceptionMapper exceptionMapper = new SmartCosmosConstraintViolationExceptionMapper();
+                throw new WebApplicationException(exceptionMapper.toResponse(new ConstraintViolationException(violations)));
+            }
+        } catch (ValidationException e)
+        {
+            e.printStackTrace();
+            throw new WebApplicationException(VALIDATION_FAILURE);
         }
     }
 }

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
@@ -1,33 +1,5 @@
 package net.smartcosmos.platform.resource;
 
-import static net.smartcosmos.Field.MONIKER_FIELD;
-import static net.smartcosmos.Field.NULL_MONIKER;
-
-import java.io.IOException;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Set;
-import java.util.SortedSet;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicLong;
-
-import javax.validation.ConstraintViolation;
-import javax.validation.ConstraintViolationException;
-import javax.validation.Validation;
-import javax.validation.Validator;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.CacheControl;
-import javax.ws.rs.core.EntityTag;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 /*
  * *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*
  * SMART COSMOS Platform Server API
@@ -53,7 +25,6 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-
 import io.dropwizard.views.View;
 import net.smartcosmos.model.base.EntityReferenceType;
 import net.smartcosmos.model.base.IDomainResource;
@@ -68,6 +39,32 @@ import net.smartcosmos.platform.util.SmartCosmosConstraintViolationExceptionMapp
 import net.smartcosmos.pojo.base.ResponseEntity;
 import net.smartcosmos.pojo.base.Result;
 import net.smartcosmos.util.json.ViewType;
+import org.joda.time.format.DateTimeFormatter;
+import org.joda.time.format.ISODateTimeFormat;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.validation.ConstraintViolation;
+import javax.validation.ConstraintViolationException;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.CacheControl;
+import javax.ws.rs.core.EntityTag;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.SortedSet;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import static net.smartcosmos.Field.MONIKER_FIELD;
+import static net.smartcosmos.Field.NULL_MONIKER;
 
 public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
 {
@@ -185,7 +182,7 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
      * @return returns the validated domain resource
      * @throws WebApplicationException
      */
-    public <ENTITY> ENTITY parseWithoutValidation(final String jsonString, final Class<ENTITY> targetEntityClass)
+    public <ENTITY extends IDomainResource> ENTITY parseWithoutValidation(final String jsonString, final Class<ENTITY> targetEntityClass)
             throws WebApplicationException
     {
         ENTITY entity = null;
@@ -217,7 +214,7 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
      * @return returns the validated domain resource
      * @throws WebApplicationException
      */
-    public <ENTITY> ENTITY parse(final String jsonString, final Class<ENTITY> targetEntityClass)
+    public <ENTITY extends IDomainResource> ENTITY parse(final String jsonString, final Class<ENTITY> targetEntityClass)
             throws WebApplicationException
     {
         ENTITY entity = parseWithoutValidation(jsonString, targetEntityClass);
@@ -306,7 +303,7 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
         return om;
     }
 
-    private <ENTITY> ENTITY jsonToEntity(final String jsonString, final Class<ENTITY> targetEntityClass)
+    private <ENTITY extends IDomainResource> ENTITY jsonToEntity(final String jsonString, final Class<ENTITY> targetEntityClass)
             throws IOException
     {
         ObjectMapper mapper = createObjectMapper();
@@ -322,7 +319,7 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
      *            the sub-type of DomainResourceEntity
      * @throws WebApplicationException
      */
-    public <ENTITY> void validate(final ENTITY entity) throws WebApplicationException
+    public <ENTITY extends IDomainResource> void validate(final ENTITY entity) throws WebApplicationException
     {
         Validator validator = Validation.buildDefaultValidatorFactory().getValidator();
         Set<ConstraintViolation<ENTITY>> violations = validator.validate(entity);

--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/base/AbstractBaseClient.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/base/AbstractBaseClient.java
@@ -1,7 +1,11 @@
 package net.smartcosmos.client.impl.base;
 
-import java.util.Arrays;
-
+import net.smartcosmos.client.connectivity.ServerContext;
+import net.smartcosmos.client.connectivity.ServiceException;
+import net.smartcosmos.pojo.base.ResponseEntity;
+import net.smartcosmos.pojo.base.Result;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.restlet.Client;
 import org.restlet.Context;
 import org.restlet.data.ChallengeResponse;
@@ -10,6 +14,11 @@ import org.restlet.data.Protocol;
 import org.restlet.resource.ClientResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+
+import static net.smartcosmos.Field.CODE_FIELD;
+import static net.smartcosmos.Field.MESSAGE_FIELD;
 
 /*
  * *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*
@@ -30,8 +39,6 @@ import org.slf4j.LoggerFactory;
  * limitations under the License.
  * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
  */
-
-import net.smartcosmos.client.connectivity.ServerContext;
 
 public abstract class AbstractBaseClient
 {
@@ -91,5 +98,27 @@ public abstract class AbstractBaseClient
                 .getServerUrl()
                 .concat(context.getContextPath())
                 .concat(path);
+    }
+
+    protected void throwServiceException(JSONObject jsonResult) throws ServiceException
+    {
+        try
+        {
+            if (jsonResult.has(CODE_FIELD) && jsonResult.has(MESSAGE_FIELD))
+            {
+                ResponseEntity responseEntity = new ResponseEntity();
+                responseEntity.setCode(jsonResult.getInt(CODE_FIELD));
+                responseEntity.setMessage(jsonResult.getString(MESSAGE_FIELD));
+
+                throw new ServiceException(responseEntity);
+
+            } else if (jsonResult.has(CODE_FIELD))
+            {
+                throw new ServiceException(jsonResult.getInt(CODE_FIELD));
+            }
+        } catch (JSONException e)
+        {
+            throw new ServiceException(Result.ERR_FAILURE.getCode());
+        }
     }
 }

--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/PutCommand.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/PutCommand.java
@@ -117,36 +117,19 @@ public class PutCommand<T> extends AbstractBaseClient implements ICommand<T, T>
 
             }
 
-            if (!service.getStatus().equals(Status.SUCCESS_CREATED))
-            {
-                LOGGER.error("Unexpected HTTP status code returned: {}", service.getStatus().getCode());
-
-                try
-                {
-                    if (jsonResult.has(CODE_FIELD) && jsonResult.has(MESSAGE_FIELD))
-                    {
-                        ResponseEntity responseEntity = new ResponseEntity();
-                        responseEntity.setCode(jsonResult.getInt(CODE_FIELD));
-                        responseEntity.setMessage(jsonResult.getString(MESSAGE_FIELD));
-
-                        throw new ServiceException(responseEntity);
-
-                    } else if (jsonResult.has(CODE_FIELD))
-                    {
-                        throw new ServiceException(jsonResult.getInt(CODE_FIELD));
-                    }
-                } catch (JSONException e)
-                {
-                    throw new ServiceException(Result.ERR_FAILURE.getCode());
-                }
-            } else
+            Status status = service.getStatus();
+            if (status.equals(Status.SUCCESS_CREATED))
             {
                 if (clazz.isAssignableFrom(ResponseEntity.class))
                 {
                     LOGGER.debug(((ResponseEntity) response).getMessage());
                 }
-            }
+            } else
+            {
+                LOGGER.error("Unexpected HTTP status code returned: {}", service.getStatus().getCode());
 
+                throwServiceException(jsonResult);
+            }
         } catch (JSONException | IOException e)
         {
             LOGGER.error("Unexpected Exception", e);
@@ -175,24 +158,7 @@ public class PutCommand<T> extends AbstractBaseClient implements ICommand<T, T>
                 LOGGER.error("Unexpected HTTP status code returned: {}", service.getStatus().getCode());
 
                 JSONObject jsonResult = jsonRepresentation.getJsonObject();
-                try
-                {
-                    if (jsonResult.has(CODE_FIELD) && jsonResult.has(MESSAGE_FIELD))
-                    {
-                        ResponseEntity responseEntity = new ResponseEntity();
-                        responseEntity.setCode(jsonResult.getInt(CODE_FIELD));
-                        responseEntity.setMessage(jsonResult.getString(MESSAGE_FIELD));
-
-                        throw new ServiceException(responseEntity);
-
-                    } else if (jsonResult.has(CODE_FIELD))
-                    {
-                        throw new ServiceException(jsonResult.getInt(CODE_FIELD));
-                    }
-                } catch (JSONException e)
-                {
-                    throw new ServiceException(Result.ERR_FAILURE.getCode());
-                }
+                throwServiceException(jsonResult);
             } else
             {
                 JSONArray jsonResult = jsonRepresentation.getJsonArray();

--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/UpsertCommand.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/UpsertCommand.java
@@ -25,7 +25,6 @@ import net.smartcosmos.client.connectivity.ServerContext;
 import net.smartcosmos.client.connectivity.ServiceException;
 import net.smartcosmos.client.impl.base.AbstractBaseClient;
 import net.smartcosmos.pojo.base.ResponseEntity;
-import net.smartcosmos.pojo.base.Result;
 import net.smartcosmos.util.json.JsonUtil;
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -41,9 +40,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-
-import static net.smartcosmos.Field.CODE_FIELD;
-import static net.smartcosmos.Field.MESSAGE_FIELD;
 
 public class UpsertCommand<T> extends AbstractBaseClient implements ICommand<T, T>
 {
@@ -87,25 +83,7 @@ public class UpsertCommand<T> extends AbstractBaseClient implements ICommand<T, 
             {
                 JSONObject jsonResult = jsonRepresentation.getJsonObject();
                 LOGGER.error("Unexpected HTTP status code returned: {}", service.getStatus().getCode());
-
-                try
-                {
-                    if (jsonResult.has(CODE_FIELD) && jsonResult.has(MESSAGE_FIELD))
-                    {
-                        ResponseEntity responseEntity = new ResponseEntity();
-                        responseEntity.setCode(jsonResult.getInt(CODE_FIELD));
-                        responseEntity.setMessage(jsonResult.getString(MESSAGE_FIELD));
-
-                        throw new ServiceException(responseEntity);
-
-                    } else if (jsonResult.has(CODE_FIELD))
-                    {
-                        throw new ServiceException(jsonResult.getInt(CODE_FIELD));
-                    }
-                } catch (JSONException e)
-                {
-                    throw new ServiceException(Result.ERR_FAILURE.getCode());
-                }
+                throwServiceException(jsonResult);
             }
 
         } catch (JSONException | IOException e)
@@ -140,25 +118,7 @@ public class UpsertCommand<T> extends AbstractBaseClient implements ICommand<T, 
             } else
             {
                 LOGGER.error("Unexpected HTTP status code returned: {}", service.getStatus().getCode());
-
-                try
-                {
-                    if (jsonResult.has(CODE_FIELD) && jsonResult.has(MESSAGE_FIELD))
-                    {
-                        ResponseEntity responseEntity = new ResponseEntity();
-                        responseEntity.setCode(jsonResult.getInt(CODE_FIELD));
-                        responseEntity.setMessage(jsonResult.getString(MESSAGE_FIELD));
-
-                        throw new ServiceException(responseEntity);
-
-                    } else if (jsonResult.has(CODE_FIELD))
-                    {
-                        throw new ServiceException(jsonResult.getInt(CODE_FIELD));
-                    }
-                } catch (JSONException e)
-                {
-                    throw new ServiceException(Result.ERR_FAILURE.getCode());
-                }
+                throwServiceException(jsonResult);
             }
 
         } catch (JSONException | IOException e)


### PR DESCRIPTION
**OBJECTS-511** prepares the POJOs in `net.smartcosmos` for validation usage:
- validation annotations for POJO fields
-  validation constraint values as fields in the interfaces to be used by both POJOs _and_ entities (before we had different values in some instances)

In addition, I refactored code duplications in the command classed of the java-client and moved the service exception throwing to the `AbstractBaseClient`.