### PR TITLE
improve message for class loading failures

### DIFF
--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/util/ClassUtil.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/util/ClassUtil.java
@@ -40,7 +40,7 @@ public final class ClassUtil
             instance = clazz.cast(Class.forName(className, true, classLoader).newInstance());
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e)
         {
-            LOG.error("Unable to instantiate class named {}", className);
+            LOG.error("Unable to instantiate class named {}, cause: {}", className, e.toString());
         }
 
         return instance;
@@ -55,7 +55,7 @@ public final class ClassUtil
             instance = clazz.cast(Class.forName(className).newInstance());
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e)
         {
-            LOG.error("Unable to instantiate class named {}", className);
+            LOG.error("Unable to instantiate class named {}, cause: {}", className, e.toString());
         }
 
         return instance;


### PR DESCRIPTION
The current message output covers three broad categories of exception and does not provide the extra information required to effectively diagnose the problem with the class load failure.  Adding in the "toString()" of the exception to the message output during the failure will allow the developer to more quickly and easily diagnose the problem without having to resort to step debugging.