### PR TITLE
Feature/support default aws api key format

### DIFF
--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractAwsService.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractAwsService.java
@@ -57,8 +57,30 @@ public abstract class AbstractAwsService<U> extends AbstractCloudService<U>
     @Override
     protected U createCloudCredentials(Properties properties)
     {
-        String accessKey = properties.getProperty(ACCESS_KEY);
-        String secretAccessKey = properties.getProperty(SECRET_KEY);
+        String accessKey = null;
+        String secretAccessKey = null;
+
+        // If the incoming AWS API key file is a CSV file (which is what you download from AWS by default),
+        // we've already marked it as a CSV file in net.smartcosmos.platform.base.AbstractCloudService, so
+        // here we just strip out the two irrelevant lines, split the key of the relevant line on ",", and
+        // use the second and third fields as access key and secret key respectively.
+        // We assume here that the user has left the extension alone on the key file, whatever she's done
+        // with it in terms of base name and location.
+
+        if (properties.containsKey("csv") && properties.get("csv").equals("true"))
+        {
+            properties.remove("csv");
+            properties.remove("User");
+            String relevantLine = (String) properties.propertyNames().nextElement();
+            String[] relevantTokens = relevantLine.split(",");
+            accessKey = relevantTokens[1];
+            secretAccessKey = relevantTokens[2];
+        }
+        else
+        {
+            accessKey = properties.getProperty(ACCESS_KEY);
+            secretAccessKey = properties.getProperty(SECRET_KEY);
+        }
 
         return createCloudCredentials(accessKey, secretAccessKey);
     }

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractAwsService.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractAwsService.java
@@ -75,8 +75,7 @@ public abstract class AbstractAwsService<U> extends AbstractCloudService<U>
             String[] relevantTokens = relevantLine.split(",");
             accessKey = relevantTokens[1];
             secretAccessKey = relevantTokens[2];
-        }
-        else
+        } else
         {
             accessKey = properties.getProperty(ACCESS_KEY);
             secretAccessKey = properties.getProperty(SECRET_KEY);

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractCloudService.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractCloudService.java
@@ -28,7 +28,6 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Properties;
-import java.util.Scanner;
 
 /**
  * Base class for any Cloud-backed service offering that provides a simple Properties file based mechanism for loading
@@ -133,6 +132,6 @@ public abstract class AbstractCloudService<U> extends AbstractService
     protected void onMissingFileAtServiceKeyPath(String cloudCredentialsPath)
     {
         LOG.error("Unable to locate Cloud credential properties at path found in configuration file: {}",
-                  cloudCredentialsPath);
+            cloudCredentialsPath);
     }
 }

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractCloudService.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractCloudService.java
@@ -28,6 +28,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.Properties;
+import java.util.Scanner;
 
 /**
  * Base class for any Cloud-backed service offering that provides a simple Properties file based mechanism for loading
@@ -81,8 +82,18 @@ public abstract class AbstractCloudService<U> extends AbstractService
                 try
                 {
                     InputStream is = new FileInputStream(cloudCredentialsFile);
+
+                    // we just load the properties directly, as if we know it's a .properties file
                     properties.load(is);
 
+                    // If the file is a .csv file, as per e.g., the AWS default format, we add a property that says so,
+                    // so we can do service-specific parsing later.
+                    // See net.smartcosmos.platform.base.AbstractAwsService for an (at this writing the only) example.
+
+                    if (cloudCredentialsFile.getName().endsWith(".csv"))
+                    {
+                        properties.put("csv", "true");
+                    }
                     credentials = createCloudCredentials(properties);
 
                 } catch (Exception e)


### PR DESCRIPTION
Assumes that if the key file is in AWS default format, the file extension (".csv") has been left alone.
Java-compliant properties files work as before.
