### PR TITLE
Bugfix/objects 487 interaction validation

### DIFF
--- a/smartcosmos-core/src/main/java/net/smartcosmos/Field.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/Field.java
@@ -90,6 +90,8 @@ public final class Field
 
     public static final String OBJECT_INTERACTION_SESSION_FIELD = "objectInteractionSession";
 
+    public static final String OBJECT_INTERACTION_SESSION_URN_FIELD = "objectInteractionSessionUrn";
+
     public static final String START_TIMESTAMP_FIELD = "startTimestamp";
 
     public static final String STOP_TIMESTAMP_FIELD = "stopTimestamp";

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/builder/InteractionBuilder.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/builder/InteractionBuilder.java
@@ -66,5 +66,6 @@ public final class InteractionBuilder extends AbstractReferentialBuilder<IObject
     protected void onValidate()
     {
         Preconditions.checkNotNull(instance.getType(), "type must not be null");
+        Preconditions.checkState(instance.getRecordedTimestamp() > 0, "recordedTimestamp must be set");
     }
 }

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/ObjectInteraction.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/ObjectInteraction.java
@@ -20,9 +20,11 @@ package net.smartcosmos.objects.pojo.context;
  * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
  */
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.google.common.base.Preconditions;
+import net.smartcosmos.Field;
 import net.smartcosmos.model.context.IAccount;
 import net.smartcosmos.objects.model.context.IObject;
 import net.smartcosmos.objects.model.context.IObjectInteraction;
@@ -34,6 +36,7 @@ import net.smartcosmos.util.json.JsonGenerationView;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+@JsonIgnoreProperties({Field.OBJECT_URN_FIELD, Field.OBJECT_INTERACTION_SESSION_URN_FIELD})
 public class ObjectInteraction extends ReferentialObject<IObjectInteraction> implements IObjectInteraction
 {
     @JsonView(JsonGenerationView.Full.class)
@@ -46,6 +49,7 @@ public class ObjectInteraction extends ReferentialObject<IObjectInteraction> imp
     protected IObject object;
 
     @JsonView(JsonGenerationView.Standard.class)
+    @NotNull
     protected long recordedTimestamp;
 
     @JsonView(JsonGenerationView.Full.class)
@@ -169,7 +173,6 @@ public class ObjectInteraction extends ReferentialObject<IObjectInteraction> imp
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + account.hashCode();
         result = 31 * result + object.hashCode();
         result = 31 * result + (int) (recordedTimestamp ^ (recordedTimestamp >>> 32));
         result = 31 * result + (int) (receivedTimestamp ^ (receivedTimestamp >>> 32));

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/ObjectInteraction.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/ObjectInteraction.java
@@ -32,6 +32,7 @@ import net.smartcosmos.objects.model.context.IObjectInteractionSession;
 import net.smartcosmos.pojo.base.ReferentialObject;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.Min;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
@@ -44,7 +45,7 @@ public class ObjectInteraction extends ReferentialObject<IObjectInteraction> imp
     protected IObject object;
 
     @JsonView(JsonGenerationView.Standard.class)
-    @NotNull
+    @Min(value = 1)
     protected long recordedTimestamp;
 
     @JsonView(JsonGenerationView.Full.class)

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/ObjectInteraction.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/ObjectInteraction.java
@@ -30,7 +30,6 @@ import net.smartcosmos.objects.model.context.IObject;
 import net.smartcosmos.objects.model.context.IObjectInteraction;
 import net.smartcosmos.objects.model.context.IObjectInteractionSession;
 import net.smartcosmos.pojo.base.ReferentialObject;
-import net.smartcosmos.pojo.context.Account;
 import net.smartcosmos.util.json.JsonGenerationView;
 
 import javax.validation.constraints.NotNull;
@@ -39,10 +38,6 @@ import javax.validation.constraints.Size;
 @JsonIgnoreProperties({Field.OBJECT_URN_FIELD, Field.OBJECT_INTERACTION_SESSION_URN_FIELD})
 public class ObjectInteraction extends ReferentialObject<IObjectInteraction> implements IObjectInteraction
 {
-    @JsonView(JsonGenerationView.Full.class)
-    @JsonDeserialize(as = Account.class)
-    protected IAccount account;
-
     @JsonView(JsonGenerationView.Minimum.class)
     @JsonDeserialize(as = ObjectImpl.class)
     @NotNull
@@ -173,7 +168,7 @@ public class ObjectInteraction extends ReferentialObject<IObjectInteraction> imp
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + object.hashCode();
+        result = 31 * result + (object != null ? object.hashCode() : 0);
         result = 31 * result + (int) (recordedTimestamp ^ (recordedTimestamp >>> 32));
         result = 31 * result + (int) (receivedTimestamp ^ (receivedTimestamp >>> 32));
         result = 31 * result + (hasSessionMembership ? 1 : 0);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/ReferentialObject.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/ReferentialObject.java
@@ -28,6 +28,8 @@ import net.smartcosmos.model.context.IAccount;
 import net.smartcosmos.pojo.context.Account;
 import net.smartcosmos.util.json.JsonGenerationView;
 
+import javax.validation.constraints.NotNull;
+
 public abstract class ReferentialObject<T> extends DomainResource<T> implements IReferentialObject
 {
     @JsonView(JsonGenerationView.Full.class)
@@ -38,6 +40,7 @@ public abstract class ReferentialObject<T> extends DomainResource<T> implements 
     protected EntityReferenceType entityReferenceType;
 
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
     protected String referenceUrn;
 
     @Override
@@ -96,9 +99,9 @@ public abstract class ReferentialObject<T> extends DomainResource<T> implements 
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + account.hashCode();
-        result = 31 * result + entityReferenceType.hashCode();
-        result = 31 * result + referenceUrn.hashCode();
+        result = 31 * result + (account != null ? account.hashCode() : 0);
+        result = 31 * result + (entityReferenceType != null ? entityReferenceType.hashCode() : 0);
+        result = 31 * result + (referenceUrn != null ? referenceUrn.hashCode() : 0);
         return result;
     }
 }

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/Result.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/Result.java
@@ -47,6 +47,7 @@ public enum Result implements IResult
     ERR_MISSING_AUTHENTICATION_HEADER(-14, "Endpoint requires authentication"),
     ERR_VALIDATION(-15, "Validation Failure"),
     ERR_EMPTY_REQUEST(-16, "Request body must not be empty"),
+    ERR_PARSE_ERROR(-17, "Unable to parse input"),
 
     ERR_EXTENSION_SECURITY_RESTRICTION(-50, "Extensions are not permitted to perform %s"),
     ERR_EXTENSION_NO_ACCESS(-51, "Caller lacked the authorization to complete the requested operation"),
@@ -60,6 +61,7 @@ public enum Result implements IResult
     ERR_LIBRARY_NO_SUCH_ELEMENT_TYPE(-71, "There is no library element type called %s"),
     ERR_LIBRARY_WRONG_PARENT_TYPE(-72, "Library element type %s cannot be the parent to a library element of type %s"),
     ERR_LIBRARY_DUPLICATE_NAME_FOR_PARENT(-73, "Parent element %s already has a child named %s"),
+    ERR_LIBRARY_CANNOT_DELETE_ELEMENT(-74, "Library element cannot be deleted"),
     ERR_LIBRARY_CANNOT_DELETE_ELEMENT_WITH_CHILDREN(-74, "Library element %s has children and cannot be deleted"),
     ERR_LIBRARY_CANNOT_DELETE_ELEMENT_WITH_RELATIONSHIPS(-74, "Library element %s has relationships and cannot be deleted"),
     ERR_LIBRARY_CANNOT_LINK_TO_LIBRARY_ELEMENT_TYPE(-75, "Library element type %s cannot accept links"),
@@ -119,12 +121,34 @@ public enum Result implements IResult
                 return ERR_NO_SUCH_EMAIL;
             case -13:
                 return ERR_NO_FILE_CONTENT;
+            case -14:
+                return ERR_MISSING_AUTHENTICATION_HEADER;
+            case -15:
+                return ERR_VALIDATION;
+            case -16:
+                return ERR_EMPTY_REQUEST;
+            case -17:
+                return ERR_PARSE_ERROR;
             case -50:
                 return ERR_EXTENSION_SECURITY_RESTRICTION;
             case -51:
                 return ERR_EXTENSION_NO_ACCESS;
             case -500:
                 return ERR_INTERNAL;
+            case -70:
+                return ERR_LIBRARY_PARENT_NOT_FOUND;
+            case -71:
+                return ERR_LIBRARY_NO_SUCH_ELEMENT_TYPE;
+            case -72:
+                return ERR_LIBRARY_WRONG_PARENT_TYPE;
+            case -73:
+            return ERR_LIBRARY_DUPLICATE_NAME_FOR_PARENT;
+            case -74:
+                return ERR_LIBRARY_CANNOT_DELETE_ELEMENT;
+            case -75:
+                return ERR_LIBRARY_CANNOT_LINK_TO_LIBRARY_ELEMENT_TYPE;
+            case -76:
+                return ERR_WRONG_RELATIONSHIP_TYPE_FOR_LIBRARYELEMENT;
             default:
                 throw new IllegalArgumentException("Unknown Result: " + code);
         }

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
@@ -20,9 +20,12 @@ package net.smartcosmos.platform.resource;
  * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
  */
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.exc.InvalidFormatException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import io.dropwizard.views.View;
@@ -200,6 +203,33 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
             try
             {
                 entity = jsonToEntity(jsonString, targetClass);
+            } catch (JsonParseException e)
+            {
+                LOG.warn(e.getMessage());
+                response = Response.status(Response.Status.BAD_REQUEST)
+                        .type(MediaType.APPLICATION_JSON_TYPE)
+                        .entity(ResponseEntity.toJson(Result.ERR_FAILURE, "Parsing error: " + e.getMessage()))
+                        .build();
+            } catch (JsonMappingException e)
+            {
+                LOG.warn(e.getMessage());
+                if (e instanceof InvalidFormatException)
+                {
+                    InvalidFormatException invalidFormatException = (InvalidFormatException) e;
+
+                    if (invalidFormatException.getTargetType().equals(EntityReferenceType.class))
+                    {
+                        response = Response.status(Response.Status.BAD_REQUEST)
+                                .type(MediaType.APPLICATION_JSON_TYPE)
+                                .entity(ResponseEntity.toJson(Result.ERR_UNKNOWN_ENTITY_TYPE, invalidFormatException.getValue()))
+                                .build();
+                    }
+                }
+
+                if (response == null)
+                {
+                    response = VALIDATION_FAILURE;
+                }
             } catch (IOException e)
             {
                 LOG.warn(e.getMessage());

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/resource/AbstractRequestHandler.java
@@ -205,10 +205,10 @@ public abstract class AbstractRequestHandler<T> implements IRequestHandler<T>
                 entity = jsonToEntity(jsonString, targetClass);
             } catch (JsonParseException e)
             {
-                LOG.warn(e.getMessage());
+                LOG.warn("Unable to parse JSON Input: " + e.getMessage());
                 response = Response.status(Response.Status.BAD_REQUEST)
                         .type(MediaType.APPLICATION_JSON_TYPE)
-                        .entity(ResponseEntity.toJson(Result.ERR_FAILURE, "Parsing error: " + e.getMessage()))
+                        .entity(ResponseEntity.toJson(Result.ERR_PARSE_ERROR))
                         .build();
             } catch (JsonMappingException e)
             {


### PR DESCRIPTION
**Results**
* modified `Result.translate()` to include all results defined in `Result.java`
* introduced result code for parse errors
* added _generic_ error code `-74` for library element delete errors to resolve conflict between `ERR_LIBRARY_CANNOT_DELETE_ELEMENT_WITH_CHILDREN` and `ERR_LIBRARY_CANNOT_DELETE_ELEMENT_WITH_RELATIONSHIPS`

**Fields**
* added `objectInteractionSessionUrn` for create interaction request (cf. `objectUrn` and `object`)

**Validation & Parsing**
* fixed constraints for `recordedTimestamp` validation
* added `recordedTimestamp` validation to `InteractionBuilder`
* fine-grained parsing exception handling

**POJOs**
* removed `account` field from `ObjectInteraction` (obscured field in super class)
* added null checks for more robust `hashCode()` methods
