### PR TITLE
Feature/objects 552 extension init exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Bugfixes / Improvements
 
+- OBJECTS-552 Improve Extension Configuration Exception Handling: if reading extension configuration fails, a `RuntimeException` is thrown
 - new error result code for parse errors: `ERR_PARSE_ERROR`
 - new general error result code `ERR_LIBRARY_CANNOT_DELETE_ELEMENT` to resolve conflict between `ERR_LIBRARY_CANNOT_DELETE_ELEMENT_WITH_CHILDREN` and `ERR_LIBRARY_CANNOT_DELETE_ELEMENT_WITH_RELATIONSHIPS`
 - `Result.translate()` can translate all results defined in `Result.java` now

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractServerExtension.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractServerExtension.java
@@ -27,14 +27,14 @@ import io.dropwizard.setup.Environment;
 import net.smartcosmos.platform.api.IContext;
 import net.smartcosmos.platform.api.ext.IServerExtension;
 import net.smartcosmos.platform.configuration.SmartCosmosConfiguration;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.Collections;
 import java.util.List;
 
-public abstract class AbstractServerExtension<T extends AbstractSmartCosmosExtensionConfiguration>
-        implements IServerExtension<T>
+public abstract class AbstractServerExtension<T extends AbstractSmartCosmosExtensionConfiguration> implements IServerExtension<T>
 {
     private static final Logger LOG = LoggerFactory.getLogger(AbstractServerExtension.class);
 
@@ -91,23 +91,30 @@ public abstract class AbstractServerExtension<T extends AbstractSmartCosmosExten
     @Override
     public void initialize(Bootstrap<?> bootstrap)
     {
-        ConfigurationFactory<T> cf = new DefaultConfigurationFactoryFactory<T>()
-                .create(extensionConfigurationClass,
-                        bootstrap.getValidatorFactory().getValidator(),
-                        bootstrap.getObjectMapper(),
-                        "dw");
+        ConfigurationFactory<T> cf = new DefaultConfigurationFactoryFactory<T>().create(extensionConfigurationClass,
+                bootstrap.getValidatorFactory().getValidator(),
+                bootstrap.getObjectMapper(),
+                "dw");
 
-        try
+        if (extensionConfigurationPath != null && !extensionConfigurationPath.isEmpty())
         {
-            extensionConfiguration = (T) cf.build(bootstrap.getConfigurationSourceProvider(),
-                    getServerExtensionConfigurationPath());
-
-            initialize(extensionConfiguration);
-
-        } catch (Exception e)
+            try
+            {
+                extensionConfiguration = (T) cf.build(bootstrap.getConfigurationSourceProvider(), extensionConfigurationPath);
+                initialize(extensionConfiguration);
+            } catch (Exception e)
+            {
+                handleInitializationException(e);
+            }
+        } else
         {
-            handleInitializationException(e);
+            handleMissingConfigurationException();
         }
+    }
+
+    protected void handleMissingConfigurationException()
+    {
+        LOG.error("Server extension {} has no configuration.", name);
     }
 
     protected void initialize(T extensionConfiguration) throws Exception
@@ -117,8 +124,8 @@ public abstract class AbstractServerExtension<T extends AbstractSmartCosmosExten
 
     protected void handleInitializationException(Exception e)
     {
-        LOG.error("Exception during extension initialization: " + e.getMessage());
-        e.printStackTrace();
+        LOG.error("Exception during extension initialization: {}", e.toString());
+        LOG.debug(ExceptionUtils.getFullStackTrace(e));
     }
 
     @Override

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractServerExtension.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/base/AbstractServerExtension.java
@@ -108,13 +108,8 @@ public abstract class AbstractServerExtension<T extends AbstractSmartCosmosExten
             }
         } else
         {
-            handleMissingConfigurationException();
+            throw new RuntimeException("Server extension " + name + " has no configuration.");
         }
-    }
-
-    protected void handleMissingConfigurationException()
-    {
-        LOG.error("Server extension {} has no configuration.", name);
     }
 
     protected void initialize(T extensionConfiguration) throws Exception
@@ -122,10 +117,11 @@ public abstract class AbstractServerExtension<T extends AbstractSmartCosmosExten
 
     }
 
-    protected void handleInitializationException(Exception e)
+    protected void handleInitializationException(Exception e) throws RuntimeException
     {
         LOG.error("Exception during extension initialization: {}", e.toString());
         LOG.debug(ExceptionUtils.getFullStackTrace(e));
+        throw new RuntimeException(e);
     }
 
     @Override

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/util/ClassUtil.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/util/ClassUtil.java
@@ -55,7 +55,7 @@ public final class ClassUtil
             instance = clazz.cast(Class.forName(className).newInstance());
         } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e)
         {
-            LOG.error("Unable to instantiate class named {}", className);
+            LOG.error("Unable to instantiate class named {}: {}", className, e.toString());
         }
 
         return instance;


### PR DESCRIPTION
Improves Extension Configuration Exception Handling: if reading extension configuration fails, a `RuntimeException` is thrown