### PR TITLE
Bugfix/objects 564 registration validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,3 +14,4 @@
 - new `objectInteractionSessionUrn` field for create interaction request (cf. `objectUrn` and `object`)
 - more robust `hashCode()` methods in POJO classes
 - improved input validation for interactions
+- validation constraints in `User` and `Registration` POJO classes

--- a/smartcosmos-core/pom.xml
+++ b/smartcosmos-core/pom.xml
@@ -74,6 +74,10 @@
             <artifactId>reflections-maven</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.dropwizard</groupId>
+            <artifactId>dropwizard-hibernate</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-core</artifactId>
             <exclusions>

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/context/User.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/context/User.java
@@ -27,6 +27,7 @@ import net.smartcosmos.model.context.RoleType;
 import net.smartcosmos.pojo.base.DomainResource;
 import net.smartcosmos.util.UuidUtil;
 import net.smartcosmos.util.json.JsonGenerationView;
+import org.hibernate.validator.constraints.Email;
 
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
@@ -43,6 +44,7 @@ public class User extends DomainResource< IUser > implements IUser
 
     @JsonView(JsonGenerationView.Minimum.class)
     @NotNull
+    @Email
     @Size(max = EMAIL_ADDRESS_MAX_LENGTH)
     private String emailAddress;
 

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/api/authentication/IRegistration.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/api/authentication/IRegistration.java
@@ -40,6 +40,10 @@ import net.smartcosmos.model.base.IAccountDomainResource;
  */
 public interface IRegistration extends IAccountDomainResource<IRegistration>
 {
+    int REALM_MAX_LENGTH = 128;
+    int ADMIN_USER_URN_MAX_LENGTH = 767;
+    int EMAIL_VERIFICATION_TOKEN_LENGTH = 16;
+
     String getEmailAddress();
 
     void setEmailAddress(String emailAddress);

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/UserEntity.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/jpa/UserEntity.java
@@ -25,11 +25,14 @@ import net.smartcosmos.model.context.IUser;
 import net.smartcosmos.model.context.RoleType;
 import net.smartcosmos.platform.jpa.base.DomainResourceAccountEntity;
 import net.smartcosmos.util.json.JsonGenerationView;
+import org.hibernate.validator.constraints.Email;
 
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 import java.io.Serializable;
 
 @Entity(name = "account_user")
@@ -39,14 +42,21 @@ public class UserEntity extends DomainResourceAccountEntity<IUser>implements IUs
 
     @JsonView(JsonGenerationView.Minimum.class)
     @Column(length = EMAIL_ADDRESS_MAX_LENGTH, nullable = false, updatable = false)
+    @Email
+    @NotNull
+    @Size(max = EMAIL_ADDRESS_MAX_LENGTH)
     protected String emailAddress;
 
     @JsonView(JsonGenerationView.Full.class)
     @Column(length = GIVEN_NAME_MAX_LENGTH, nullable = false)
+    @NotNull
+    @Size(max = GIVEN_NAME_MAX_LENGTH)
     protected String givenName;
 
     @JsonView(JsonGenerationView.Full.class)
     @Column(length = SURNAME_MAX_LENGTH, nullable = false)
+    @NotNull
+    @Size(max = SURNAME_MAX_LENGTH)
     protected String surname;
 
     @JsonView(JsonGenerationView.Minimum.class)

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/pojo/authentication/Registration.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/pojo/authentication/Registration.java
@@ -23,23 +23,35 @@ package net.smartcosmos.platform.pojo.authentication;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import net.smartcosmos.model.context.IAccount;
+import net.smartcosmos.model.context.IUser;
 import net.smartcosmos.platform.api.authentication.IRegistration;
 import net.smartcosmos.pojo.base.DomainResource;
 import net.smartcosmos.pojo.context.Account;
 import net.smartcosmos.util.json.JsonGenerationView;
+import org.hibernate.validator.constraints.Email;
+
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 public final class Registration extends DomainResource<IRegistration> implements IRegistration
 {
     @JsonView(JsonGenerationView.Minimum.class)
+    @NotNull
+    @Email
+    @Size(max = IUser.EMAIL_ADDRESS_MAX_LENGTH)
     protected String emailAddress;
 
     @JsonView(JsonGenerationView.Minimum.class)
+    @Size(max = IRegistration.REALM_MAX_LENGTH)
+    @NotNull
     protected String realm;
 
     @JsonView(JsonGenerationView.Full.class)
+    @Size(max = IRegistration.ADMIN_USER_URN_MAX_LENGTH)
     protected String adminUserUrn;
 
     @JsonView(JsonGenerationView.Standard.class)
+    @Size(max = IRegistration.EMAIL_VERIFICATION_TOKEN_LENGTH)
     protected String emailVerificationToken;
 
     @JsonView(JsonGenerationView.Full.class)

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/pojo/authentication/Registration.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/pojo/authentication/Registration.java
@@ -20,6 +20,7 @@ package net.smartcosmos.platform.pojo.authentication;
  * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
  */
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonView;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import net.smartcosmos.model.context.IAccount;
@@ -33,6 +34,7 @@ import org.hibernate.validator.constraints.Email;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
+@JsonIgnoreProperties({"sendRegistrationEmail"})
 public final class Registration extends DomainResource<IRegistration> implements IRegistration
 {
     @JsonView(JsonGenerationView.Minimum.class)


### PR DESCRIPTION
* adds `@NotNull`, `@Size` and `@Email` annotations in user and registration POJO and Entity classes
* uses constants for field length constraints instead of hard-coded values

*Prepares the validation for registration (pull request for Objects will follow soon)*