### PR TITLE
New constraint validation annotation for realms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bugfixes & Improvements
 
+* added a reusable compound validation constraint annotation for realms (OBJECTS-568)
+
 ## Release 2.12.1 (January 21, 2016)
 
 ### New Features

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/constraint/annotation/ValidRealm.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/constraint/annotation/ValidRealm.java
@@ -1,0 +1,56 @@
+package net.smartcosmos.platform.constraint.annotation;
+
+/*
+ * *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*
+ * SMART COSMOS Extension API
+ * ===============================================================================
+ * Copyright (C) 2013 - 2016 Smartrac Technology Fletcher, Inc.
+ * ===============================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
+ */
+
+import net.smartcosmos.platform.api.authentication.IRegistration;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@NotNull
+@Size(min = 1, max = IRegistration.REALM_MAX_LENGTH)
+@Documented
+@Constraint(validatedBy = {})
+@Target({ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE, ElementType.ANNOTATION_TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ValidRealm
+{
+    String message() default "Realm is not valid";
+
+    Class<?>[] groups() default {};
+
+    Class<? extends Payload>[] payload() default {};
+
+    @Target({ElementType.METHOD, ElementType.FIELD, ElementType.ANNOTATION_TYPE, ElementType.CONSTRUCTOR, ElementType.PARAMETER})
+    @Retention(RetentionPolicy.RUNTIME)
+    @Documented
+    @interface List
+    {
+        ValidRealm[] value();
+    }
+}

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/constraint/annotation/package-info.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/constraint/annotation/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Collection of validation annotations for extended field validation.
+ */
+package net.smartcosmos.platform.constraint.annotation;

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/pojo/authentication/Registration.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/pojo/authentication/Registration.java
@@ -26,6 +26,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import net.smartcosmos.model.context.IAccount;
 import net.smartcosmos.model.context.IUser;
 import net.smartcosmos.platform.api.authentication.IRegistration;
+import net.smartcosmos.platform.constraint.annotation.ValidRealm;
 import net.smartcosmos.pojo.base.DomainResource;
 import net.smartcosmos.pojo.context.Account;
 import net.smartcosmos.util.json.JsonGenerationView;
@@ -44,8 +45,7 @@ public final class Registration extends DomainResource<IRegistration> implements
     protected String emailAddress;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    @Size(max = IRegistration.REALM_MAX_LENGTH)
-    @NotNull
+    @ValidRealm
     protected String realm;
 
     @JsonView(JsonGenerationView.Full.class)


### PR DESCRIPTION
* added a new `@ValidRealm` validation constraint annotation to be used whenever realms need to be validated
* allows to extend the constraints in future without the need to change more than a single place