### PR TITLE
Bugfix/objects 582 upsert resource exception

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bugfixes & Improvements
 
 * added a reusable compound validation constraint annotation for realms (OBJECTS-568)
+* OBJECTS-582 Java Client UpsertCommand does not catch ResourceException
 
 ## Release 2.12.1 (January 21, 2016)
 

--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/base/AbstractBaseClient.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/base/AbstractBaseClient.java
@@ -121,4 +121,16 @@ public abstract class AbstractBaseClient
             throw new ServiceException(Result.ERR_FAILURE.getCode());
         }
     }
+
+    protected void throwServiceException(String responseEntity) throws ServiceException
+    {
+        try
+        {
+            JSONObject jsonResponse = new JSONObject(responseEntity);
+            throwServiceException(jsonResponse);
+        } catch (JSONException e)
+        {
+            throw new ServiceException(Result.ERR_FAILURE.getCode());
+        }
+    }
 }

--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/UpsertCommand.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/UpsertCommand.java
@@ -34,6 +34,7 @@ import org.restlet.data.Status;
 import org.restlet.ext.json.JsonRepresentation;
 import org.restlet.representation.Representation;
 import org.restlet.resource.ClientResource;
+import org.restlet.resource.ResourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,11 +86,17 @@ public class UpsertCommand<T> extends AbstractBaseClient implements ICommand<T, 
                 LOGGER.error("Unexpected HTTP status code returned: {}", service.getStatus().getCode());
                 throwServiceException(jsonResult);
             }
-
-        } catch (JSONException | IOException e)
+        } catch (JSONException | IOException | ResourceException e)
         {
-            LOGGER.error("Unexpected Exception", e);
-            throw new ServiceException(e);
+            if (e instanceof  ResourceException)
+            {
+                LOGGER.error("Unexpected HTTP status code returned: {}", service.getStatus().getCode());
+                throwServiceException(service.getResponse().getEntityAsText());
+            } else
+            {
+                LOGGER.error("Unexpected Exception", e);
+                throw new ServiceException(e);
+            }
         }
 
         return responses;
@@ -121,7 +128,7 @@ public class UpsertCommand<T> extends AbstractBaseClient implements ICommand<T, 
                 throwServiceException(jsonResult);
             }
 
-        } catch (JSONException | IOException e)
+        } catch (JSONException | IOException | ResourceException e)
         {
             LOGGER.error("Unexpected Exception", e);
             throw new ServiceException(e);


### PR DESCRIPTION
More or less a quick fix because the command classes generally need a revision:
https://smartractechnology.atlassian.net/browse/OBJECTS-583

* catch `ResourceException` and throw `ServiceException`
* add new `throwServiceException()` method that takes a String parameter to avoid a potential `JSONException` in the catch block