### PR TITLE
Feature/client exception handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * added a reusable compound validation constraint annotation for realms (OBJECTS-568)
 * OBJECTS-582 Java Client `UpsertCommand` and `GetCollectionCommand` does not catch `ResourceException`
+* OBJECTS-584 Add method to create ResponseEntity from Result
 
 ## Release 2.12.1 (January 21, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 ### Bugfixes & Improvements
 
 * added a reusable compound validation constraint annotation for realms (OBJECTS-568)
-* OBJECTS-582 Java Client UpsertCommand does not catch ResourceException
+* OBJECTS-582 Java Client `UpsertCommand` and `GetCollectionCommand` does not catch `ResourceException`
 
 ## Release 2.12.1 (January 21, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * added a reusable compound validation constraint annotation for realms (OBJECTS-568)
 * OBJECTS-582 Java Client `UpsertCommand` and `GetCollectionCommand` does not catch `ResourceException`
 * OBJECTS-584 Add method to create ResponseEntity from Result
+* OBJECTS-585 MetadataClient throws ServiceException when looking up by key
 
 ## Release 2.12.1 (January 21, 2016)
 

--- a/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/ResponseEntity.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/pojo/base/ResponseEntity.java
@@ -109,11 +109,17 @@ public class ResponseEntity
 
     public static<RESULT_ENUM_TYPE extends IResult> String toJson(RESULT_ENUM_TYPE result, Object... args)
     {
-        ResponseEntity re = new ResponseEntity();
-        re.setMessage(String.format(result.getFormattedMessage(), args));
-        re.setCode(result.getCode());
+        ResponseEntity responseEntity = toResponseEntity(result, args);
+        return JsonUtil.toJson(responseEntity);
+    }
 
-        return JsonUtil.toJson(re);
+    public static<RESULT_ENUM_TYPE extends IResult> ResponseEntity toResponseEntity(RESULT_ENUM_TYPE result, Object... args)
+    {
+        ResponseEntity responseEntity = new ResponseEntity();
+        responseEntity.setMessage(String.format(result.getFormattedMessage(), args));
+        responseEntity.setCode(result.getCode());
+
+        return responseEntity;
     }
 
     public void log()

--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/common/metadata/MetadataClient.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/common/metadata/MetadataClient.java
@@ -32,6 +32,7 @@ import net.smartcosmos.model.base.EntityReferenceType;
 import net.smartcosmos.model.context.IMetadata;
 import net.smartcosmos.model.context.MetadataDataType;
 import net.smartcosmos.pojo.base.ResponseEntity;
+import net.smartcosmos.pojo.base.Result;
 import net.smartcosmos.pojo.context.Metadata;
 import net.smartcosmos.util.json.JsonUtil;
 import net.smartcosmos.util.json.ViewType;
@@ -167,7 +168,13 @@ class MetadataClient extends AbstractUpsertableBaseClient<IMetadata> implements 
                 MetadataEndpoints.findSpecificKey(entityReferenceType, referenceUrn, key, viewType));
         if (matches.size() != 1)
         {
-            throw new ServiceException(new Exception("Unexpected number of results."));
+            if (matches.size() == 0)
+            {
+                return null;
+            } else
+            {
+                throw new ServiceException(ResponseEntity.toResponseEntity(Result.ERR_FAILURE, "Unexpected number of results."));
+            }
         }
         return matches.iterator().next();
     }

--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/common/metadata/MetadataClient.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/common/metadata/MetadataClient.java
@@ -21,6 +21,20 @@ package net.smartcosmos.client.common.metadata;
  */
 
 import com.google.common.base.Preconditions;
+import net.smartcosmos.Field;
+import net.smartcosmos.client.connectivity.ServerContext;
+import net.smartcosmos.client.connectivity.ServiceException;
+import net.smartcosmos.client.impl.base.AbstractUpsertableBaseClient;
+import net.smartcosmos.client.impl.command.DeleteCommand;
+import net.smartcosmos.client.impl.command.GetCollectionCommand;
+import net.smartcosmos.client.impl.endpoint.MetadataEndpoints;
+import net.smartcosmos.model.base.EntityReferenceType;
+import net.smartcosmos.model.context.IMetadata;
+import net.smartcosmos.model.context.MetadataDataType;
+import net.smartcosmos.pojo.base.ResponseEntity;
+import net.smartcosmos.pojo.context.Metadata;
+import net.smartcosmos.util.json.JsonUtil;
+import net.smartcosmos.util.json.ViewType;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -36,22 +50,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
-
-import net.smartcosmos.Field;
-import net.smartcosmos.client.connectivity.ServerContext;
-import net.smartcosmos.client.connectivity.ServiceException;
-import net.smartcosmos.client.impl.base.AbstractUpsertableBaseClient;
-import net.smartcosmos.client.impl.command.DeleteCommand;
-import net.smartcosmos.client.impl.command.GetCollectionCommand;
-//import net.smartcosmos.client.impl.command.GetCommand;
-import net.smartcosmos.client.impl.endpoint.MetadataEndpoints;
-import net.smartcosmos.model.base.EntityReferenceType;
-import net.smartcosmos.model.context.IMetadata;
-import net.smartcosmos.model.context.MetadataDataType;
-import net.smartcosmos.pojo.base.ResponseEntity;
-import net.smartcosmos.pojo.context.Metadata;
-import net.smartcosmos.util.json.JsonUtil;
-import net.smartcosmos.util.json.ViewType;
 
 import static net.smartcosmos.Field.ENTITY_REFERENCE_TYPE;
 import static net.smartcosmos.Field.KEY_FIELD;

--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/common/metadata/MetadataClient.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/common/metadata/MetadataClient.java
@@ -166,14 +166,16 @@ class MetadataClient extends AbstractUpsertableBaseClient<IMetadata> implements 
         GetCollectionCommand<IMetadata> command = new GetCollectionCommand<>(context, getClient());
         Collection<IMetadata> matches = command.call(Metadata.class,
                 MetadataEndpoints.findSpecificKey(entityReferenceType, referenceUrn, key, viewType));
-        if (matches.size() != 1)
+        int resultCount = matches.size();
+        if (resultCount != 1)
         {
-            if (matches.size() == 0)
+            if (resultCount == 0)
             {
                 return null;
             } else
             {
-                throw new ServiceException(ResponseEntity.toResponseEntity(Result.ERR_FAILURE, "Unexpected number of results."));
+                throw new ServiceException(ResponseEntity.toResponseEntity(Result.ERR_FAILURE,
+                        "Unexpected number of results: " + String.valueOf(resultCount)));
             }
         }
         return matches.iterator().next();

--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/base/AbstractBaseClient.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/base/AbstractBaseClient.java
@@ -12,6 +12,7 @@ import org.restlet.data.ChallengeResponse;
 import org.restlet.data.ChallengeScheme;
 import org.restlet.data.Protocol;
 import org.restlet.resource.ClientResource;
+import org.restlet.resource.ResourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -131,6 +132,19 @@ public abstract class AbstractBaseClient
         } catch (JSONException e)
         {
             throw new ServiceException(Result.ERR_FAILURE.getCode());
+        }
+    }
+
+    protected void throwServiceException(ClientResource service, Exception e) throws ServiceException
+    {
+        if (e instanceof ResourceException)
+        {
+            log.error("Unexpected HTTP status code returned: {}", service.getStatus().getCode());
+            throwServiceException(service.getResponse().getEntityAsText());
+        } else
+        {
+            log.error("Unexpected Exception", e);
+            throw new ServiceException(e);
         }
     }
 }

--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/GetCollectionCommand.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/GetCollectionCommand.java
@@ -1,5 +1,25 @@
 package net.smartcosmos.client.impl.command;
 
+/*
+ * *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*
+ * SMART COSMOS Platform Client
+ * ===============================================================================
+ * Copyright (C) 2013 - 2014 SMARTRAC Technology Fletcher, Inc.
+ * ===============================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
+ */
+
 import net.smartcosmos.client.connectivity.ServerContext;
 import net.smartcosmos.client.connectivity.ServiceException;
 import net.smartcosmos.client.impl.base.AbstractBaseClient;
@@ -20,26 +40,6 @@ import org.slf4j.LoggerFactory;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
-
-/*
- * *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*
- * SMART COSMOS Platform Client
- * ===============================================================================
- * Copyright (C) 2013 - 2014 SMARTRAC Technology Fletcher, Inc.
- * ===============================================================================
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
- */
 
 public class GetCollectionCommand<T> extends AbstractBaseClient implements ICommand<Collection<T>, T>
 {

--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/GetCollectionCommand.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/GetCollectionCommand.java
@@ -1,9 +1,10 @@
 package net.smartcosmos.client.impl.command;
 
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Collection;
-
+import net.smartcosmos.client.connectivity.ServerContext;
+import net.smartcosmos.client.connectivity.ServiceException;
+import net.smartcosmos.client.impl.base.AbstractBaseClient;
+import net.smartcosmos.pojo.base.ResponseEntity;
+import net.smartcosmos.util.json.JsonUtil;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -12,8 +13,13 @@ import org.restlet.data.Status;
 import org.restlet.ext.json.JsonRepresentation;
 import org.restlet.representation.Representation;
 import org.restlet.resource.ClientResource;
+import org.restlet.resource.ResourceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
 
 /*
  * *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*
@@ -24,9 +30,9 @@ import org.slf4j.LoggerFactory;
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *      http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -34,12 +40,6 @@ import org.slf4j.LoggerFactory;
  * limitations under the License.
  * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
  */
-
-import net.smartcosmos.client.connectivity.ServerContext;
-import net.smartcosmos.client.connectivity.ServiceException;
-import net.smartcosmos.client.impl.base.AbstractBaseClient;
-import net.smartcosmos.pojo.base.ResponseEntity;
-import net.smartcosmos.util.json.JsonUtil;
 
 public class GetCollectionCommand<T> extends AbstractBaseClient implements ICommand<Collection<T>, T>
 {
@@ -100,10 +100,9 @@ public class GetCollectionCommand<T> extends AbstractBaseClient implements IComm
                 throw new ServiceException(responseEntity);
             }
 
-        } catch (JSONException | IOException e)
+        } catch (JSONException | IOException | ResourceException e)
         {
-            LOGGER.error("Unexpected Exception", e);
-            throw new ServiceException(e);
+            throwServiceException(service, e);
         }
 
         return matches;

--- a/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/UpsertCommand.java
+++ b/smartcosmos-java-client/src/main/java/net/smartcosmos/client/impl/command/UpsertCommand.java
@@ -88,15 +88,7 @@ public class UpsertCommand<T> extends AbstractBaseClient implements ICommand<T, 
             }
         } catch (JSONException | IOException | ResourceException e)
         {
-            if (e instanceof  ResourceException)
-            {
-                LOGGER.error("Unexpected HTTP status code returned: {}", service.getStatus().getCode());
-                throwServiceException(service.getResponse().getEntityAsText());
-            } else
-            {
-                LOGGER.error("Unexpected Exception", e);
-                throw new ServiceException(e);
-            }
+            throwServiceException(service, e);
         }
 
         return responses;


### PR DESCRIPTION
Basically the same as already merged pull request https://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework/pull/98, this time for `GetCollectionCommand`

In addition, it removes a workaround that used a new Exception to create a ServiceException with just a message, although `ServiceException (String message)` is disabled. For that, I added a new method to `ResponseEntity` that allows to build response entities from an `IResult`.

Using `new ResponseEntity()` and `setCode()` + `setMessage()` instead would lose the "message templates" and code-message dependencies defined in `Result`.

Moreover, finding nothing is a valid result for `findSpecificKey()` in `MetadataClient` now. In this case, it returns `null`. Otherwise it would not be possible to distinguish between not finding anything and the unlikely case of finding too much.