### PR TITLE
Objects 321 Default Values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Bugfixes & Improvements
 
 * added a reusable compound validation constraint annotation for realms (OBJECTS-568)
+* added default values for `TimelineEntry` (OBJECTS-321)
 * OBJECTS-582 Java Client `UpsertCommand` and `GetCollectionCommand` does not catch `ResourceException`
 * OBJECTS-584 Add method to create ResponseEntity from Result
 * OBJECTS-585 MetadataClient throws ServiceException when looking up by key

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/TimelineEntry.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/TimelineEntry.java
@@ -145,7 +145,7 @@ public class TimelineEntry extends ReferentialObject<ITimelineEntry> implements 
     public int hashCode()
     {
         int result = super.hashCode();
-        result = 31 * result + name.hashCode();
+        result = 31 * result + (name != null ? name.hashCode() : 0);
         result = 31 * result + (description != null ? description.hashCode() : 0);
         result = 31 * result + (highlightFlag ? 1 : 0);
         result = 31 * result + (visibleFlag ? 1 : 0);

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/TimelineEntry.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/TimelineEntry.java
@@ -39,16 +39,16 @@ public class TimelineEntry extends ReferentialObject<ITimelineEntry> implements 
     protected String description;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    protected boolean highlightFlag;
+    protected boolean highlightFlag = true;
 
     @JsonView(JsonGenerationView.Standard.class)
-    protected boolean visibleFlag;
+    protected boolean visibleFlag = true;
 
     @JsonView(JsonGenerationView.Standard.class)
-    protected boolean activeFlag;
+    protected boolean activeFlag = true;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    protected long timelineTimestamp;
+    protected long timelineTimestamp = 0;
 
     @Override
     public String getName()


### PR DESCRIPTION
Adds default values to the `TimelineEntry` POJO because `timeline.CreateRequestHandler` does not "parse" the JSON model by hand anymore (), but uses common parsing methods therefore not set fields would default to `false` (https://github.com/SMARTRACTECHNOLOGY/smartcosmos-objects/pull/166).

To avoid additional JSON model examination, the default values are added directly to the POJO class now.