### PR TITLE
Bugfix/objects 586 unsupported custom type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 * OBJECTS-582 Java Client `UpsertCommand` and `GetCollectionCommand` does not catch `ResourceException`
 * OBJECTS-584 Add method to create ResponseEntity from Result
 * OBJECTS-585 MetadataClient throws ServiceException when looking up by key
+* OBJECTS-586 MetadataCodec does not support `Custom` MetadataDataType
 
 ## Release 2.12.1 (January 21, 2016)
 

--- a/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/TimelineEntry.java
+++ b/smartcosmos-core/src/main/java/net/smartcosmos/objects/pojo/context/TimelineEntry.java
@@ -39,16 +39,16 @@ public class TimelineEntry extends ReferentialObject<ITimelineEntry> implements 
     protected String description;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    protected boolean highlightFlag = true;
+    protected boolean highlightFlag;
 
     @JsonView(JsonGenerationView.Standard.class)
-    protected boolean visibleFlag = true;
+    protected boolean visibleFlag;
 
     @JsonView(JsonGenerationView.Standard.class)
-    protected boolean activeFlag = true;
+    protected boolean activeFlag;
 
     @JsonView(JsonGenerationView.Minimum.class)
-    protected long timelineTimestamp = 0;
+    protected long timelineTimestamp;
 
     @Override
     public String getName()

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/util/MetadataCodec.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/util/MetadataCodec.java
@@ -1,10 +1,5 @@
 package net.smartcosmos.platform.util;
 
-import java.util.UnknownFormatConversionException;
-
-import org.json.JSONException;
-import org.json.JSONObject;
-
 /*
  * *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*
  * SMART COSMOS Platform Server API
@@ -35,6 +30,10 @@ import net.smartcosmos.util.mapper.IntegerMapper;
 import net.smartcosmos.util.mapper.JsonMapper;
 import net.smartcosmos.util.mapper.LongMapper;
 import net.smartcosmos.util.mapper.StringMapper;
+import org.json.JSONException;
+import org.json.JSONObject;
+
+import java.util.UnknownFormatConversionException;
 
 /**
  *
@@ -60,11 +59,11 @@ public final class MetadataCodec
      */
     public static String encodeMetadata(MetadataDataType dataType, String dataToEncode)
     {
-
         String resultString;
         switch (dataType)
         {
         case StringType:
+        case Custom:
         case XMLType:
             resultString = new StringMapper().toString(dataToEncode);
             break;
@@ -132,6 +131,7 @@ public final class MetadataCodec
             switch (dataType)
             {
             case StringType:
+            case Custom:
             case XMLType:
                 outputJson.put(Field.DECODED_VALUE_FIELD, new StringMapper().fromString(dataToDecode));
                 break;


### PR DESCRIPTION
- add `Custom` to `MetadataCodec` with same behavior as `StringType` and `XMLType`.

Prevents the following error during `Metadata` serialization:
```
ERROR [2016-02-05 11:44:43,437] net.smartcosmos.util.json.JsonUtil: Unable to convert object to JSON: Unsupported data type: Custom (through reference chain: net.smartcosmos.objects.jpa.MetadataEntity["decodedValue"])
```