### PR TITLE
Feature/sce 20 21 22 fix endpoint config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@
 
 ### Bugfixes / Improvements
 
+* OBJECTS-377 Add data validation annotation for Metadata
 * OBJECTS-620 Refer to Images Locally instead of remotely in documentation
+* SCE-20 get Device endpoints out of `EndpointsFactory`
+* SCE-21 get Hashtag endpoints out of `EndpointsFactory`
 * Add separate SDKs for different AWS services to `smartcosmos-dependencies` (SCE-19)
 * Fix smartcosmos dependency scope in `smartcosmos-extension-archetype`
 * Extract Geospatial from Objects into separate "Geospatial Extension" (OBJECTS-622)
-* OBJECTS-377: Add data validation annotation for Metadata
 
 ## Release 2.13.1 (March 8, 2016)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * OBJECTS-620 Refer to Images Locally instead of remotely in documentation
 * SCE-20 get Device endpoints out of `EndpointsFactory`
 * SCE-21 get Hashtag endpoints out of `EndpointsFactory`
+* SCE-22 get Geospatial endpoints out of `EndpointsFactory`
 * Add separate SDKs for different AWS services to `smartcosmos-dependencies` (SCE-19)
 * Fix smartcosmos dependency scope in `smartcosmos-extension-archetype`
 * Extract Geospatial from Objects into separate "Geospatial Extension" (OBJECTS-622)

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/EndpointsFactory.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/EndpointsFactory.java
@@ -34,13 +34,7 @@ public class EndpointsFactory
     private Boolean objectAddressEndpoint = true;
 
     @JsonProperty
-    private Boolean deviceEndpoints = true;
-
-    @JsonProperty
     private Boolean metadataEndpoints = true;
-
-    @JsonProperty
-    private Boolean tagEndpoints = true;
 
     @JsonProperty
     private Boolean timelineEndpoints = true;
@@ -117,19 +111,9 @@ public class EndpointsFactory
         return timelineEndpoints;
     }
 
-    public Boolean getTagEndpoints()
-    {
-        return tagEndpoints;
-    }
-
     public Boolean getMetadataEndpoints()
     {
         return metadataEndpoints;
-    }
-
-    public Boolean getDeviceEndpoints()
-    {
-        return deviceEndpoints;
     }
 
     public Boolean getObjectAddressEndpoint()

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/EndpointsFactory.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/EndpointsFactory.java
@@ -40,9 +40,6 @@ public class EndpointsFactory
     private Boolean timelineEndpoints = true;
 
     @JsonProperty
-    private Boolean geospatialEndpoints = true;
-
-    @JsonProperty
     private Boolean relationshipEndpoints = true;
 
     @JsonProperty
@@ -99,11 +96,6 @@ public class EndpointsFactory
     public Boolean getRelationshipEndpoints()
     {
         return relationshipEndpoints;
-    }
-
-    public Boolean getGeospatialEndpoints()
-    {
-        return geospatialEndpoints;
     }
 
     public Boolean getTimelineEndpoints()

--- a/smartcosmos-extension-starter-parent/smartcosmos-extension-archetype/src/main/resources/archetype-resources/src/main/resources/objects.yml
+++ b/smartcosmos-extension-starter-parent/smartcosmos-extension-archetype/src/main/resources/archetype-resources/src/main/resources/objects.yml
@@ -134,9 +134,7 @@ endpoints:
   eventsEndpoint: true
   objectAddressEndpoint: true
   metadataEndpoints: true
-  tagEndpoints: true
   timelineEndpoints: true
-  geospatialEndpoints: true
   relationshipEndpoints: true
   interactionEndpoints: true
   objectEndpoints: true
@@ -202,11 +200,6 @@ endpointMethodControl:
   relationships.reference.type.get: true
   relationships.reference.get: true
 
-  geospatial.put: true
-  geospatial.post: true
-  geospatial.get: true
-  geospatial.urn.get: true
-
   metadata.encode.post: true
   metadata.decode.post: true
   metadata.reference.put: true
@@ -221,14 +214,6 @@ endpointMethodControl:
   files.urn.contents.get: true
   files.entity.reference.get: true
   files.urn.delete: true
-
-  tags.put: true
-  tags.tag.get: true
-  tags.urn.get: true
-  tags.tag.reference.put: true
-  tags.get: true
-  tags.tag.delete: true
-  tags.tag.reference.delete: true
 
   notifications.enroll.put: true
   notifications.confirm.put: true


### PR DESCRIPTION
Removed extension endpoints from the `EndpointsFactory` since configuration in the `objects.yml` is not used anymore. Extension read the endpoint master control flag from the `extension.yml`.

Configurations that still include the following will fail during startup due to unrecognized fields:
```
endpoints:
   deviceEndpoints: true
   geospatialEndpoints: true
   tagEndpoints: true
```

However, endpoint method control has to remain in `objects.yml`.

**Related pull requests:**
- https://github.com/SMARTRACTECHNOLOGY/smartcosmos-extension-device/pull/15
- https://github.com/SMARTRACTECHNOLOGY/smartcosmos-extension-geospatial/pull/2
- https://github.com/SMARTRACTECHNOLOGY/smartcosmos-extension-hashtag/pull/12
- https://github.com/SMARTRACTECHNOLOGY/smartcosmos-objects/pull/200