### PR TITLE
Feature/objects 670 671 metrics configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### New Features
 
-* Support for `/metrics` configuration in `SmartCosmosConfiguration` (OBJECTS-671)
+* Support for (optional) `/metrics` configuration in `SmartCosmosConfiguration` (OBJECTS-671)
 * Add validation for `metrics` endpoint configuration (OBJECTS-670)
 
 ### Bugfixes / Improvements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,8 @@
 
 ### New Features
 
-* No new features are added in this release.
+* Support for `/metrics` configuration in `SmartCosmosConfiguration` (OBJECTS-671)
+* Add validation for `metrics` endpoint configuration (OBJECTS-670)
 
 ### Bugfixes / Improvements
 

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/SmartCosmosConfiguration.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/SmartCosmosConfiguration.java
@@ -125,8 +125,8 @@ public class SmartCosmosConfiguration extends Configuration
     @JsonProperty
     private boolean supportStatusCheck;
 
-    @JsonProperty
-    private Boolean supportMonitoring;
+    @Valid
+    private SmartCosmosMetricsFactory metricsFactory = new SmartCosmosMetricsFactory();
 
     @JsonProperty
     private boolean supportNotifications;
@@ -374,6 +374,12 @@ public class SmartCosmosConfiguration extends Configuration
         this.supportStatusCheck = flag;
     }
 
+    @JsonProperty("metrics")
+    public void setMetricsFactory(final SmartCosmosMetricsFactory smartCosmosMetricsFactory)
+    {
+        this.metricsFactory = smartCosmosMetricsFactory;
+    }
+
     public void setSupportUsers(final boolean flag)
     {
         this.supportUsers = flag;
@@ -420,9 +426,10 @@ public class SmartCosmosConfiguration extends Configuration
         return supportStatusCheck;
     }
 
-    public Boolean supportMonitoring()
+    @JsonProperty("metrics")
+    public SmartCosmosMetricsFactory getSmartCosmosMetricsFactory()
     {
-        return supportMonitoring;
+        return metricsFactory;
     }
 
     public boolean supportUsers()
@@ -458,7 +465,7 @@ public class SmartCosmosConfiguration extends Configuration
                ", supportRealmCheck=" + supportRealmCheck +
                ", supportDynamicRegistration=" + supportDynamicRegistration +
                ", supportStatusCheck=" + supportStatusCheck +
-               ", supportMonitoring=" + supportMonitoring +
+               ", metrics=" + metricsFactory +
                ", supportNotifications=" + supportNotifications +
                ", supportExtensions=" + supportExtensions +
                ", supportMultimediaFiles=" + supportMultimediaFiles +

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/SmartCosmosConfiguration.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/SmartCosmosConfiguration.java
@@ -20,24 +20,22 @@ package net.smartcosmos.platform.configuration;
  * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
  */
 
-import java.util.ArrayList;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import javax.validation.Valid;
-import javax.validation.constraints.NotNull;
-
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.collect.Maps;
 import io.dropwizard.Configuration;
 import io.dropwizard.client.HttpClientConfiguration;
 import io.dropwizard.db.DataSourceFactory;
-
-import org.hibernate.validator.constraints.NotEmpty;
-
 import net.smartcosmos.platform.bundle.batch.BatchFactory;
 import net.smartcosmos.platform.bundle.quartz.QuartzFactory;
 import net.smartcosmos.platform.bundle.transformation.TransformationsFactory;
+import org.hibernate.validator.constraints.NotEmpty;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotNull;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 
 public class SmartCosmosConfiguration extends Configuration
 {
@@ -126,6 +124,9 @@ public class SmartCosmosConfiguration extends Configuration
 
     @JsonProperty
     private boolean supportStatusCheck;
+
+    @JsonProperty
+    private Boolean supportMonitoring;
 
     @JsonProperty
     private boolean supportNotifications;
@@ -419,6 +420,11 @@ public class SmartCosmosConfiguration extends Configuration
         return supportStatusCheck;
     }
 
+    public Boolean supportMonitoring()
+    {
+        return supportMonitoring;
+    }
+
     public boolean supportUsers()
     {
         return supportUsers;
@@ -452,6 +458,7 @@ public class SmartCosmosConfiguration extends Configuration
                ", supportRealmCheck=" + supportRealmCheck +
                ", supportDynamicRegistration=" + supportDynamicRegistration +
                ", supportStatusCheck=" + supportStatusCheck +
+               ", supportMonitoring=" + supportMonitoring +
                ", supportNotifications=" + supportNotifications +
                ", supportExtensions=" + supportExtensions +
                ", supportMultimediaFiles=" + supportMultimediaFiles +

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/SmartCosmosMetricsFactory.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/SmartCosmosMetricsFactory.java
@@ -21,14 +21,16 @@ package net.smartcosmos.platform.configuration;
  */
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import net.smartcosmos.platform.constraint.annotation.CredentialsNotNullIfAuthEnabled;
 
+@CredentialsNotNullIfAuthEnabled
 public class SmartCosmosMetricsFactory
 {
     @JsonProperty
-    private Boolean enabled;
+    private Boolean enabled = false;
 
     @JsonProperty("basicAuth")
-    private Boolean authenticationEnabled;
+    private Boolean authenticationEnabled = false;
 
     @JsonProperty
     private String username;

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/SmartCosmosMetricsFactory.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/SmartCosmosMetricsFactory.java
@@ -1,0 +1,89 @@
+package net.smartcosmos.platform.configuration;
+
+/*
+ * *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*
+ * SMART COSMOS Extension API
+ * ===============================================================================
+ * Copyright (C) 2013 - 2016 Smartrac Technology Fletcher, Inc.
+ * ===============================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
+ */
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class SmartCosmosMetricsFactory
+{
+    @JsonProperty
+    private Boolean enabled;
+
+    @JsonProperty("basicAuth")
+    private Boolean authenticationEnabled;
+
+    @JsonProperty
+    private String username;
+
+    @JsonProperty
+    private String password;
+
+    public Boolean isEnabled()
+    {
+        return enabled;
+    }
+
+    public void setEnabled(Boolean enabled)
+    {
+        this.enabled = enabled;
+    }
+
+    public Boolean isAuthenticationEnabled()
+    {
+        return authenticationEnabled;
+    }
+
+    public void setAuthenticationEnabled(Boolean authenticationEnabled)
+    {
+        this.authenticationEnabled = authenticationEnabled;
+    }
+
+    public String getUsername()
+    {
+        return username;
+    }
+
+    public void setUsername(String username)
+    {
+        this.username = username;
+    }
+
+    public String getPassword()
+    {
+        return password;
+    }
+
+    public void setPassword(String password)
+    {
+        this.password = password;
+    }
+
+    @Override
+    public String toString()
+    {
+        return "SmartCosmosMetricsFactory{" +
+                "enabled=" + enabled +
+                ", basicAuth=" + authenticationEnabled +
+                ", username='" + username + '\'' +
+                ", password='" + password + '\'' +
+                '}';
+    }
+}

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/constraint/annotation/CredentialsNotNullIfAuthEnabled.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/constraint/annotation/CredentialsNotNullIfAuthEnabled.java
@@ -1,0 +1,51 @@
+package net.smartcosmos.platform.constraint.annotation;
+
+/*
+ * *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*
+ * SMART COSMOS Extension API
+ * ===============================================================================
+ * Copyright (C) 2013 - 2016 Smartrac Technology Fletcher, Inc.
+ * ===============================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
+ */
+
+import net.smartcosmos.platform.constraint.validator.MetricsBasicAuthValidator;
+
+import javax.validation.Constraint;
+import javax.validation.Payload;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.ANNOTATION_TYPE;
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * An annotation for check if credentials are set when Basic Authentication for Metrics endpoint is enabled.
+ */
+@Documented
+@Target({ ANNOTATION_TYPE, FIELD, PARAMETER, ElementType.TYPE})
+@Retention(RUNTIME)
+@Constraint(validatedBy = { MetricsBasicAuthValidator.class})
+public @interface CredentialsNotNullIfAuthEnabled
+{
+    String message() default "Username and password must be set if Basic Authentication is enabled";
+
+    Class<?>[] groups() default { };
+
+    Class<? extends Payload>[] payload() default {};
+}

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/constraint/validator/MetricsBasicAuthValidator.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/constraint/validator/MetricsBasicAuthValidator.java
@@ -1,0 +1,47 @@
+package net.smartcosmos.platform.constraint.validator;
+
+/*
+ * *#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*
+ * SMART COSMOS Extension API
+ * ===============================================================================
+ * Copyright (C) 2013 - 2016 Smartrac Technology Fletcher, Inc.
+ * ===============================================================================
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#*#
+ */
+
+import net.smartcosmos.platform.configuration.SmartCosmosMetricsFactory;
+import net.smartcosmos.platform.constraint.annotation.CredentialsNotNullIfAuthEnabled;
+
+import javax.validation.ConstraintValidator;
+import javax.validation.ConstraintValidatorContext;
+
+/**
+ * Checks that username and password are set if metrics endpoint is enabled and basicAuth for metrics is set to {@code true}.
+ */
+public class MetricsBasicAuthValidator implements ConstraintValidator<CredentialsNotNullIfAuthEnabled, SmartCosmosMetricsFactory>
+{
+    @Override
+    public void initialize(CredentialsNotNullIfAuthEnabled notNullIfAuthEnabled)
+    {
+
+    }
+
+    @Override
+    public boolean isValid(SmartCosmosMetricsFactory value, ConstraintValidatorContext context)
+    {
+        return (!value.isAuthenticationEnabled() ||
+                (value.isAuthenticationEnabled() && value.getUsername() != null && !value.getUsername().isEmpty() &&
+                        value.getPassword() != null && !value.getPassword().isEmpty()));
+    }
+}

--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/constraint/validator/package-info.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/constraint/validator/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Collection of validators for custom validation annotations.
+ */
+package net.smartcosmos.platform.constraint.validator;


### PR DESCRIPTION
Adds `metrics` configuration block to the `objects.yml`, e.g.:
```
metrics:
  enabled: true
  basicAuth: true
  username: metrics
  password: metrics123
```

The complete block could be omitted, so old configuration files are not effected by that change.

Minimal configuration to enable the endpoint is:
```
metrics:
  enabled: true
```
In this case `basicAuth` is implicitly set to false and `username` and `password` are not required.