### PR TITLE
Add setters in SmartCosmosConfiguration

### DIFF
--- a/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/SmartCosmosConfiguration.java
+++ b/smartcosmos-extension-api/src/main/java/net/smartcosmos/platform/configuration/SmartCosmosConfiguration.java
@@ -283,6 +283,16 @@ public class SmartCosmosConfiguration extends Configuration
         return migrateSchemaOnStartup;
     }
 
+    public void setAppInstanceName(String appInstanceName)
+    {
+        this.appInstanceName = appInstanceName;
+    }
+
+    public void setAppName(String appName)
+    {
+        this.appName = appName;
+    }
+
     @JsonProperty("batch")
     public void setBatchFactory(final BatchFactory batchFactory)
     {


### PR DESCRIPTION
Provides setters for `appName` and `appInstanceName`, is needed in https://github.com/SMARTRACTECHNOLOGY/smartcosmos-objects/pull/206 to allow for license generation without providing a complete `objects.yml`.