### PR TITLE
Add Type to SmartCosmosEvent

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/events/impl/AbstractSmartCosmosEventTemplate.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/events/impl/AbstractSmartCosmosEventTemplate.java
@@ -11,7 +11,7 @@ import net.smartcosmos.security.user.SmartCosmosUser;
 public abstract class AbstractSmartCosmosEventTemplate
         implements ISmartCosmosEventTemplate {
 
-    public abstract void convertAndSend(SmartCosmosEvent message)
+    public abstract void convertAndSend(SmartCosmosEvent<Object> message)
             throws SmartCosmosEventException;
 
     @Override

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/events/impl/RestSmartCosmosEventTemplate.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/events/impl/RestSmartCosmosEventTemplate.java
@@ -28,7 +28,7 @@ public class RestSmartCosmosEventTemplate extends AbstractSmartCosmosEventTempla
     }
 
     @Override
-    public void convertAndSend(SmartCosmosEvent message)
+    public void convertAndSend(SmartCosmosEvent<Object> message)
             throws SmartCosmosEventException {
 
         try {


### PR DESCRIPTION
Without specifying a type for the data carried by `SmartCosmosEvent`, the build fails due to unchecked operations, therefore setting the type to `Object`, like in the other methods: `Object data`