### PR TITLE
Feature/no entity found

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/exceptions/NoEntityFoundException.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/exceptions/NoEntityFoundException.java
@@ -1,9 +1,18 @@
 package net.smartcosmos.exceptions;
 
+import lombok.Getter;
+
 /**
  * @author voor
  */
 public class NoEntityFoundException extends ServiceException {
+
+    protected static final Integer ERR_FAILURE = 0;
+    protected static final Integer ERR_RECORD_NOT_EXISTS = -8;
+    protected static final Integer ERR_UNKNOWN_ENTITY = -9;
+
+    @Getter
+    private Integer code = ERR_FAILURE;
 
     public NoEntityFoundException(String message) {
         super(message);
@@ -11,5 +20,20 @@ public class NoEntityFoundException extends ServiceException {
 
     public NoEntityFoundException(String message, Throwable cause) {
         super(message, cause);
+    }
+
+    public NoEntityFoundException(String entityType, String field, String id) {
+        super(String.format("No matching %s record with %s of %s exists", entityType, field, id));
+
+        if (!"urn".equalsIgnoreCase(field)) {
+            code = ERR_RECORD_NOT_EXISTS;
+        } else {
+            code = ERR_UNKNOWN_ENTITY;
+        }
+    }
+
+    public NoEntityFoundException(String entityType, String id) {
+        super(String.format("Unknown %s entity with urn %s", entityType, id));
+        code = ERR_UNKNOWN_ENTITY;
     }
 }

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/exceptions/NoEntityFoundException.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/exceptions/NoEntityFoundException.java
@@ -23,7 +23,9 @@ public class NoEntityFoundException extends ServiceException {
     }
 
     /**
-     * This version of NoEntityFoundException produces an error message like
+     * This version of NoEntityFoundException produces an error message for entity records not matching a query parameter.
+     * 
+     * Example:
      * <code>
      *     {"code": -8, "message": "No matching Object record with objectUrn of urn:my-object-urn exists"}
      * </code>
@@ -43,7 +45,9 @@ public class NoEntityFoundException extends ServiceException {
     }
 
     /**
-     * This version of NoEntityFoundException produces an error message like
+     * This version of NoEntityFoundException produces an error message for unknown entities.
+     *
+     * Example:
      * <code>
      *     {"code": -9, "message": "Unknown Object entity with urn urn:uuid:71b81766-afb2-4be3-943f-6a24b6ae15cc"}
      * </code>

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/exceptions/NoEntityFoundException.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/exceptions/NoEntityFoundException.java
@@ -22,16 +22,35 @@ public class NoEntityFoundException extends ServiceException {
         super(message, cause);
     }
 
-    public NoEntityFoundException(String entityType, String field, String id) {
-        super(String.format("No matching %s record with %s of %s exists", entityType, field, id));
+    /**
+     * This version of NoEntityFoundException produces an error message like
+     * <code>
+     *     {"code": -8, "message": "No matching Object record with objectUrn of urn:my-object-urn exists"}
+     * </code>
+     *
+     * @param entityType the type of the entity, e.g., Object or Metadata
+     * @param fieldName the queried field, e.g., objectUrn
+     * @param fieldValue the field value
+     */
+    public NoEntityFoundException(String entityType, String fieldName, String fieldValue) {
+        super(String.format("No matching %s record with %s of %s exists", entityType, fieldName, fieldValue));
 
-        if (!"urn".equalsIgnoreCase(field)) {
+        if (!"urn".equalsIgnoreCase(fieldName)) {
             code = ERR_RECORD_NOT_EXISTS;
         } else {
             code = ERR_UNKNOWN_ENTITY;
         }
     }
 
+    /**
+     * This version of NoEntityFoundException produces an error message like
+     * <code>
+     *     {"code": -9, "message": "Unknown Object entity with urn urn:uuid:71b81766-afb2-4be3-943f-6a24b6ae15cc"}
+     * </code>
+     *
+     * @param entityType the type of the entity, e.g., Object or Metadata
+     * @param id the entity identifier, e.g. the URN
+     */
     public NoEntityFoundException(String entityType, String id) {
         super(String.format("Unknown %s entity with urn %s", entityType, id));
         code = ERR_UNKNOWN_ENTITY;

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/security/authentication/direct/DirectExceptionHandler.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/security/authentication/direct/DirectExceptionHandler.java
@@ -68,7 +68,7 @@ public class DirectExceptionHandler extends ResponseEntityExceptionHandler {
 
         logger.warn(ex.getMessage());
 
-        return handleExceptionInternal(ex, null, headers, status, request);
+        return handleExceptionInternal(ex, processNoEntityFound(ex), headers, status, request);
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
@@ -76,6 +76,8 @@ public class DirectExceptionHandler extends ResponseEntityExceptionHandler {
 
         HttpHeaders headers = new HttpHeaders();
         HttpStatus status = HttpStatus.BAD_REQUEST;
+
+        logger.warn(ex.getMessage());
 
         Set<ConstraintViolation<?>> fieldErrors = ex.getConstraintViolations();
         Set<String> fieldNames = fieldErrors.stream().map(violation -> violation.getPropertyPath().toString()).collect(Collectors.toSet());
@@ -94,6 +96,15 @@ public class DirectExceptionHandler extends ResponseEntityExceptionHandler {
 
         return handleExceptionInternal(ex, processFieldError(error), headers, status,
                 request);
+    }
+
+    private Map<String, Object> processNoEntityFound(NoEntityFoundException ex) {
+        Map<String, Object> message = new LinkedHashMap<>();
+
+        message.put("code", ex.getCode());
+        message.put("message", ex.getMessage());
+
+        return message;
     }
 
     private Map<String, Object> processConstraintViolation(Set<String> fieldNames) {

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/security/authentication/direct/DirectExceptionHandler.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/security/authentication/direct/DirectExceptionHandler.java
@@ -60,6 +60,15 @@ public class DirectExceptionHandler extends ResponseEntityExceptionHandler {
         return handleExceptionInternal(ex, null, headers, status, request);
     }
 
+    /**
+     * Customize the response for NoEntityFoundException.
+     * <p>
+     * This method logs a warning and delegates to {@link #handleExceptionInternal}.
+     *
+     * @param ex the exception
+     * @param request the current request
+     * @return a {@code ResponseEntity} instance
+     */
     @ExceptionHandler(NoEntityFoundException.class)
     protected ResponseEntity<Object> handleNoEntityFoundRequestHandlingMethod(
             NoEntityFoundException ex, WebRequest request) {


### PR DESCRIPTION
### What changes were proposed in this pull request?

The `NoEntityFoundException` is extended to allow for error response generation including code and message.

This will be useful for endpoints that return one of those v2 error results:

```
ERR_NOT_EXISTS(-8, "No matching record with %s of %s exists")
ERR_UNKNOWN_ENTITY(-9, "Unknown %s entity with urn %s")
```
### How is this patch documented?

Javadoc.
### How was this patch tested?

Will be tested in modules actually using the exception, e.g. RDAO.
#### Depends On

Nothing.
