### PR TITLE
Deprecate accountUrn

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/util/UuidUtil.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/util/UuidUtil.java
@@ -20,7 +20,6 @@ public final class UuidUtil {
     public static final String URN_SEPARATOR = ":";
     public static final String URN_PREFIX = "urn";
     public static final String URN_PREFIX_ACCOUNT = URN_PREFIX + URN_SEPARATOR + "account" + URN_SEPARATOR;
-    public static final String URN_PREFIX_TENANT = URN_PREFIX + URN_SEPARATOR + "tenant" + URN_SEPARATOR;
     public static final String URN_PREFIX_UUID = URN_PREFIX + URN_SEPARATOR + "uuid" + URN_SEPARATOR;
 
     /**
@@ -65,20 +64,6 @@ public final class UuidUtil {
     }
 
     /**
-     * Get the UUID portion of a tenant URN.
-     *
-     * @param urn the tenant URN
-     * @return the UUID
-     * @throws IllegalArgumentException
-     */
-    public static UUID getUuidFromTenantUrn(final String urn) {
-        if (StringUtils.isNotBlank(urn)&& urn.startsWith(URN_PREFIX_TENANT)) {
-            return UUID.fromString(StringUtils.substringAfterLast(urn, URN_SEPARATOR));
-        }
-        throw new IllegalArgumentException(String.format("Invalid URN: %s", urn));
-    }
-
-    /**
      * Create an account URN for a provided UUID.
      *
      * @param referenceUuid the reference UUID
@@ -90,19 +75,6 @@ public final class UuidUtil {
             return null;
         }
         return URN_PREFIX_ACCOUNT + referenceUuid.toString();
-    }
-
-    /**
-     * Create a tenant URN for a provided UUID.
-     *
-     * @param referenceUuid the reference UUID
-     * @return the Sting version (in canonical UUID-as-String format) of an input UUID
-     */
-    public static String getTenantUrnFromUuid(final UUID referenceUuid) {
-        if (referenceUuid == null) {
-            return null;
-        }
-        return URN_PREFIX_TENANT + referenceUuid.toString();
     }
 
     public static UUID getNewUuid() {

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/util/UuidUtil.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/util/UuidUtil.java
@@ -84,11 +84,25 @@ public final class UuidUtil {
      * @param referenceUuid the reference UUID
      * @return the Sting version (in canonical UUID-as-String format) of an input UUID
      */
+    @Deprecated
     public static String getAccountUrnFromUuid(final UUID referenceUuid) {
         if (referenceUuid == null) {
             return null;
         }
         return URN_PREFIX_ACCOUNT + referenceUuid.toString();
+    }
+
+    /**
+     * Create a tenant URN for a provided UUID.
+     *
+     * @param referenceUuid the reference UUID
+     * @return the Sting version (in canonical UUID-as-String format) of an input UUID
+     */
+    public static String getTenantUrnFromUuid(final UUID referenceUuid) {
+        if (referenceUuid == null) {
+            return null;
+        }
+        return URN_PREFIX_TENANT + referenceUuid.toString();
     }
 
     public static UUID getNewUuid() {

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/util/UuidUtil.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/util/UuidUtil.java
@@ -1,10 +1,9 @@
 package net.smartcosmos.util;
 
-import java.util.UUID;
-
 import lombok.AllArgsConstructor;
-
 import org.apache.commons.lang.StringUtils;
+
+import java.util.UUID;
 
 import static lombok.AccessLevel.PRIVATE;
 
@@ -21,6 +20,7 @@ public final class UuidUtil {
     public static final String URN_SEPARATOR = ":";
     public static final String URN_PREFIX = "urn";
     public static final String URN_PREFIX_ACCOUNT = URN_PREFIX + URN_SEPARATOR + "account" + URN_SEPARATOR;
+    public static final String URN_PREFIX_TENANT = URN_PREFIX + URN_SEPARATOR + "tenant" + URN_SEPARATOR;
     public static final String URN_PREFIX_UUID = URN_PREFIX + URN_SEPARATOR + "uuid" + URN_SEPARATOR;
 
     /**
@@ -56,8 +56,23 @@ public final class UuidUtil {
      * @return the UUID
      * @throws IllegalArgumentException
      */
+    @Deprecated
     public static UUID getUuidFromAccountUrn(final String urn) {
         if (StringUtils.isNotBlank(urn)&& urn.startsWith(URN_PREFIX_ACCOUNT)) {
+            return UUID.fromString(StringUtils.substringAfterLast(urn, URN_SEPARATOR));
+        }
+        throw new IllegalArgumentException(String.format("Invalid URN: %s", urn));
+    }
+
+    /**
+     * Get the UUID portion of a tenant URN.
+     *
+     * @param urn the tenant URN
+     * @return the UUID
+     * @throws IllegalArgumentException
+     */
+    public static UUID getUuidFromTenantUrn(final String urn) {
+        if (StringUtils.isNotBlank(urn)&& urn.startsWith(URN_PREFIX_TENANT)) {
             return UUID.fromString(StringUtils.substringAfterLast(urn, URN_SEPARATOR));
         }
         throw new IllegalArgumentException(String.format("Invalid URN: %s", urn));


### PR DESCRIPTION
This marks the `getUuidFromAccountUrn()` and `getAccountUrnFromUuid()` methods as deprecated since we don't wrap `tenantId` in a URN scheme anymore.