### PR TITLE
metadata event type distinguish among create, update, upsert

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/events/DefaultEventTypes.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/events/DefaultEventTypes.java
@@ -38,8 +38,10 @@ public class DefaultEventTypes {
     final public static String ThingDeactivated = "thing:deactivated";
     final public static String ThingNotFound = "thing:notFound";
     final public static String ThingDeleted = "thing:deleted";
-    
-    final public static String MetadataUpserted = "metadata:updated";
+
+    final public static String MetadataCreated = "metadata:created";
+    final public static String MetadataUpdated = "metadata:updated";
+    final public static String MetadataUpserted = "metadata:upserted";
     final public static String MetadataRead = "metadata:read";
     final public static String MetadataDeleted = "metadata:deleted";
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Metadata event types distinguish among Create, Update, Upsert.

### How is this patch documented?

String constants in code. No old values removed.

### How was this patch tested?

Covered by unit tests in ext-metadata-rdao.

#### Depends On

Nothing.

