### PR TITLE
move metadata event type declarations into enum in metadata RDAO

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/events/DefaultEventTypes.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/events/DefaultEventTypes.java
@@ -39,12 +39,6 @@ public class DefaultEventTypes {
     final public static String ThingNotFound = "thing:notFound";
     final public static String ThingDeleted = "thing:deleted";
 
-    final public static String MetadataCreated = "metadata:created";
-    final public static String MetadataUpdated = "metadata:updated";
-    final public static String MetadataUpserted = "metadata:upserted";
-    final public static String MetadataRead = "metadata:read";
-    final public static String MetadataDeleted = "metadata:deleted";
-
     final public static String InteractionCreated = "interaction:created";
     final public static String InteractionRead = "interaction:read";
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

The events types for the individual micro-services should not be defined in teh framework but in the services themselves.

### How is this patch documented?

In the code

### How was this patch tested?

ran builds and all looked good. 

#### Depends On

No but the corresponding service changes need to be updated or it will fail on the next build.
