### PR TITLE
Enable Method Security with @PreAuthorize

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <scm>
         <connection>scm:git:git://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework.git</connection>
         <developerConnection>scm:git:git@github.com:SMARTRACTECHNOLOGY/smartcosmos-framework.git</developerConnection>
-        <tag>HEAD</tag>
         <url>https://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework/tree/master/</url>
+        <tag>HEAD</tag>
     </scm>
 </project>

--- a/smartcosmos-framework/pom.xml
+++ b/smartcosmos-framework/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>spring-cloud-starter-oauth2</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/security/authentication/OAuth2SsoRdaoConfiguration.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/security/authentication/OAuth2SsoRdaoConfiguration.java
@@ -1,25 +1,31 @@
 package net.smartcosmos.security.authentication;
 
 import lombok.extern.slf4j.Slf4j;
-import net.smartcosmos.security.authentication.direct.DirectAccessDeniedHandler;
-import net.smartcosmos.security.authentication.direct.DirectUnauthorizedEntryPoint;
-import net.smartcosmos.security.authentication.direct.EnableDirectHandlers;
-import net.smartcosmos.test.security.SmartCosmosTestProperties;
-import net.smartcosmos.test.security.TestUserDetailsService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.encoding.PlaintextPasswordEncoder;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+
+import net.smartcosmos.security.authentication.direct.DirectAccessDeniedHandler;
+import net.smartcosmos.security.authentication.direct.DirectUnauthorizedEntryPoint;
+import net.smartcosmos.security.authentication.direct.EnableDirectHandlers;
+import net.smartcosmos.test.security.SmartCosmosTestProperties;
+import net.smartcosmos.test.security.TestUserDetailsService;
 
 /**
  * @author voor
@@ -28,6 +34,7 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.E
 @Configuration
 @Slf4j
 @ComponentScan
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class OAuth2SsoRdaoConfiguration {
 
     @Bean

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUser.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUser.java
@@ -5,6 +5,16 @@ import java.lang.annotation.RetentionPolicy;
 
 import org.springframework.security.test.context.support.WithSecurityContext;
 
+/**
+ * Adds a mocked {@link net.smartcosmos.security.user.SmartCosmosUser} instance to the security context. The principal will have a valid
+ * {@link org.springframework.security.core.Authentication} based on the parameters defined with the annotation. By default, the user will have the
+ * username {@code user} and password {@code password} without any authorities.
+ * <p></p>
+ * Example:
+ * <pre>
+ * {@code @WithMockSmartCosmosUser(authorities = {"https://authorities.smartcosmos.net/things/write"})}
+ * </pre>
+ */
 @Retention(RetentionPolicy.RUNTIME)
 @WithSecurityContext(factory = WithMockSmartCosmosUserSecurityContextFactory.class)
 public @interface WithMockSmartCosmosUser {

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUser.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUser.java
@@ -19,13 +19,34 @@ import org.springframework.security.test.context.support.WithSecurityContext;
 @WithSecurityContext(factory = WithMockSmartCosmosUserSecurityContextFactory.class)
 public @interface WithMockSmartCosmosUser {
 
+    /**
+     * default value: {@code urn:tenant:uuid:b5b52af3-9909-4ea4-97bf-07639d683c95}
+     * @return the mock user tenant URN
+     */
     String tenantUrn() default "urn:tenant:uuid:b5b52af3-9909-4ea4-97bf-07639d683c95";
 
+    /**
+     * default value: {@code urn:user:uuid:e2174814-eb6d-4176-978c-58390105375b}
+     * @return the mock user URN
+     */
     String usernUrn() default "urn:user:uuid:e2174814-eb6d-4176-978c-58390105375b";
 
+    /**
+     * default value: {@code user}
+     * @return the mock user username
+     */
     String username() default "user";
 
+    /**
+     * default value: {@code password}
+     * @return the mock user password
+     */
     String password() default "password";
 
+    /**
+     * Example: {@code "https://authorities.smartcosmos.net/things/write"},
+     * default: empty array
+     * @return the mock user authorities
+     */
     String[] authorities() default {};
 }

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUser.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUser.java
@@ -1,0 +1,21 @@
+package net.smartcosmos.test.security;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockSmartCosmosUserSecurityContextFactory.class)
+public @interface WithMockSmartCosmosUser {
+
+    String tenantUrn() default "urn:tenant:uuid:b5b52af3-9909-4ea4-97bf-07639d683c95";
+
+    String usernUrn() default "urn:user:uuid:e2174814-eb6d-4176-978c-58390105375b";
+
+    String username() default "user";
+
+    String password() default "password";
+
+    String[] authorities() default {};
+}

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUser.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUser.java
@@ -12,7 +12,7 @@ import org.springframework.security.test.context.support.WithSecurityContext;
  * <p></p>
  * Example:
  * <pre>
- * {@code @WithMockSmartCosmosUser(authorities = {"https://authorities.smartcosmos.net/things/write"})}
+ * {@code @WithMockSmartCosmosUser(authorities = {"https://authorities.smartcosmos.net/things/create"})}
  * </pre>
  */
 @Retention(RetentionPolicy.RUNTIME)
@@ -44,7 +44,7 @@ public @interface WithMockSmartCosmosUser {
     String password() default "password";
 
     /**
-     * Example: {@code "https://authorities.smartcosmos.net/things/write"},
+     * Example: {@code "https://authorities.smartcosmos.net/things/create"},
      * default: empty array
      * @return the mock user authorities
      */

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUserSecurityContextFactory.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUserSecurityContextFactory.java
@@ -13,6 +13,9 @@ import org.springframework.security.test.context.support.WithSecurityContextFact
 
 import net.smartcosmos.security.user.SmartCosmosUser;
 
+/**
+ * Factory for the security context with authenticated {@link SmartCosmosUser} for testing, see {@link WithMockSmartCosmosUser} annotation.
+ */
 public class WithMockSmartCosmosUserSecurityContextFactory implements WithSecurityContextFactory<WithMockSmartCosmosUser> {
 
     @Override

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUserSecurityContextFactory.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUserSecurityContextFactory.java
@@ -1,0 +1,38 @@
+package net.smartcosmos.test.security;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import net.smartcosmos.security.user.SmartCosmosUser;
+
+public class WithMockSmartCosmosUserSecurityContextFactory implements WithSecurityContextFactory<WithMockSmartCosmosUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockSmartCosmosUser user) {
+
+        String tenantUrn = user.tenantUrn();
+        String userUrn = user.usernUrn();
+        String username = user.username();
+        String password = user.password();
+        Set<GrantedAuthority> authorities = new HashSet<>();
+        for (String authority : user.authorities()) {
+            authorities.add(new SimpleGrantedAuthority(authority));
+        }
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        SmartCosmosUser principal = new SmartCosmosUser(tenantUrn, userUrn, username, password, authorities);
+        Authentication auth = new UsernamePasswordAuthenticationToken(principal, "password", principal.getAuthorities());
+        context.setAuthentication(auth);
+
+        return context;
+    }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

This adds the configuration annotation required to make `@PreAuthorize` work.

Since it is added on the framework level, the RDAOs don't need to change. The only annotation they need will remain `@EnableSmartCosmosSecurity`.

Also adds a new annotation for testing: `@WithMockSmartCosmosUser`.

This annotation allows for testing authorization and authentication. It creates a custom security context with a custom `SmartCosmosUser` instance. By default, the annotation adds a user with username `user` and password `password` to the security context, but this user doesn't have any authorities.

The annotation can be used to set a custom set of authorities, e.g.:

```
@WithMockSmartCosmosUser(authorities = {"https://authorities.smartcosmos.net/things/write"})
```

In addition to the authorities, also the other default values can be overriden by specifying the corresponding fields:
- `tenantUrn`
- `userUrn`
- `username`
- `password`

To use the annotation, you have to initialize the `mockMvc` like this:

```
this.mockMvc = MockMvcBuilders
    .webAppContextSetup(webApplicationContext)
    .apply(springSecurity())
    .build();
```

With that, it is not required to mock the `Authentication` itself. It's not even recommended to to so, because the previous testing context led to a bunch of stack overflows if `@PreAuthorized` was used.
### How is this patch documented?

Code, Javadoc.
### How was this patch tested?

Manually using Postman, and in Things Local unit tests.
#### Depends On

Nothing.
