### PR TITLE
Deprecate DefaultEventTypes to avoid confusion what to use

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/events/DefaultEventTypes.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/events/DefaultEventTypes.java
@@ -4,7 +4,9 @@ package net.smartcosmos.events;
  * Collection of SMART COSMOS events that capture virtually all interactions between a
  * user and the platform. In many ways, the event mechanism that powers the integration
  * features also indirectly provides a complete audit of user activities.
+ * @deprecated Instead of using the event types in this class, define the event types in the services actually sending events.
  */
+@Deprecated
 public class DefaultEventTypes {
 
     /*


### PR DESCRIPTION
Just deprecate the class `DefaultEventTypes`, because we decided to use enums in the services going forward.
