### PR TITLE
Add smartcosmos-test as module to framework

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
     <scm>
         <connection>scm:git:git://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework.git</connection>
         <developerConnection>scm:git:git@github.com:SMARTRACTECHNOLOGY/smartcosmos-framework.git</developerConnection>
-        <tag>HEAD</tag>
         <url>https://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework/tree/master/</url>
+        <tag>HEAD</tag>
     </scm>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>smartcosmos-framework-parent</module>
         <module>smartcosmos-framework</module>
         <module>smartcosmos-framework-messaging</module>
+        <module>smartcosmos-framework-test</module>
     </modules>
     <scm>
         <connection>scm:git:git://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework.git</connection>

--- a/smartcosmos-dependencies/pom.xml
+++ b/smartcosmos-dependencies/pom.xml
@@ -45,6 +45,11 @@
                 <version>3.0.0-SNAPSHOT</version>
             </dependency>
             <dependency>
+                <groupId>net.smartcosmos</groupId>
+                <artifactId>smartcosmos-framework-test</artifactId>
+                <version>3.0.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
                 <groupId>org.springframework.kafka</groupId>
                 <artifactId>spring-kafka</artifactId>
                 <version>${spring-kafka.version}</version>

--- a/smartcosmos-framework-test/README.adoc
+++ b/smartcosmos-framework-test/README.adoc
@@ -1,0 +1,30 @@
+= SMART COSMOS Framework Test
+
+This module provides facilities for testing SMART COSMOS RDAO resources and services.
+
+== Security
+
+=== Mocking an authenticated `SmartCosmosUser` principal
+
+You can use the `@WithMockSmartCosmosUser` annotation to mock a security context that holds an authenticated
+`SmartCosmosUser` principal. It therefore allows for testing authorization and authentication.
+
+By default, the annotation adds a user with username `user` and password `password` to the security context, but this user doesn't have any authorities.
+
+The annotation can be used to set a custom set of authorities, e.g.:
+```
+@WithMockSmartCosmosUser(authorities = {"https://authorities.smartcosmos.net/things/write"})
+```
+In addition to the authorities, also the other default values can be overridden by specifying the corresponding fields:
+- `tenantUrn`
+- `userUrn`
+- `username`
+- `password`
+
+To use the annotation, the `mockMvc` in the unit test has to be initialized like this:
+```
+this.mockMvc = MockMvcBuilders
+    .webAppContextSetup(webApplicationContext)
+    .apply(springSecurity())
+    .build();
+```

--- a/smartcosmos-framework-test/pom.xml
+++ b/smartcosmos-framework-test/pom.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>net.smartcosmos</groupId>
+        <artifactId>smartcosmos-framework-parent</artifactId>
+        <version>3.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>smartcosmos-framework-test</artifactId>
+
+    <name>SMART COSMOS Framework Test</name>
+    <description>Facilities for testing SMART COSMOS RDAO resources and services</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.smartcosmos</groupId>
+            <artifactId>smartcosmos-framework</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/smartcosmos-framework-test/pom.xml
+++ b/smartcosmos-framework-test/pom.xml
@@ -1,13 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
         <groupId>net.smartcosmos</groupId>
         <artifactId>smartcosmos-framework-parent</artifactId>
         <version>3.0.0-SNAPSHOT</version>
+        <relativePath>../smartcosmos-framework-parent/pom.xml</relativePath>
     </parent>
 
     <artifactId>smartcosmos-framework-test</artifactId>

--- a/smartcosmos-framework-test/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUser.java
+++ b/smartcosmos-framework-test/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUser.java
@@ -1,0 +1,52 @@
+package net.smartcosmos.test.security;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+/**
+ * Adds a mocked {@link net.smartcosmos.security.user.SmartCosmosUser} instance to the security context. The principal will have a valid
+ * {@link org.springframework.security.core.Authentication} based on the parameters defined with the annotation. By default, the user will have the
+ * username {@code user} and password {@code password} without any authorities.
+ * <p></p>
+ * Example:
+ * <pre>
+ * {@code @WithMockSmartCosmosUser(authorities = {"https://authorities.smartcosmos.net/things/create"})}
+ * </pre>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockSmartCosmosUserSecurityContextFactory.class)
+public @interface WithMockSmartCosmosUser {
+
+    /**
+     * default value: {@code urn:tenant:uuid:b5b52af3-9909-4ea4-97bf-07639d683c95}
+     * @return the mock user tenant URN
+     */
+    String tenantUrn() default "urn:tenant:uuid:b5b52af3-9909-4ea4-97bf-07639d683c95";
+
+    /**
+     * default value: {@code urn:user:uuid:e2174814-eb6d-4176-978c-58390105375b}
+     * @return the mock user URN
+     */
+    String usernUrn() default "urn:user:uuid:e2174814-eb6d-4176-978c-58390105375b";
+
+    /**
+     * default value: {@code user}
+     * @return the mock user username
+     */
+    String username() default "user";
+
+    /**
+     * default value: {@code password}
+     * @return the mock user password
+     */
+    String password() default "password";
+
+    /**
+     * Example: {@code "https://authorities.smartcosmos.net/things/create"},
+     * default: empty array
+     * @return the mock user authorities
+     */
+    String[] authorities() default {};
+}

--- a/smartcosmos-framework-test/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUserSecurityContextFactory.java
+++ b/smartcosmos-framework-test/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUserSecurityContextFactory.java
@@ -1,0 +1,41 @@
+package net.smartcosmos.test.security;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import net.smartcosmos.security.user.SmartCosmosUser;
+
+/**
+ * Factory for the security context with authenticated {@link SmartCosmosUser} for testing, see {@link WithMockSmartCosmosUser} annotation.
+ */
+public class WithMockSmartCosmosUserSecurityContextFactory implements WithSecurityContextFactory<WithMockSmartCosmosUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockSmartCosmosUser user) {
+
+        String tenantUrn = user.tenantUrn();
+        String userUrn = user.usernUrn();
+        String username = user.username();
+        String password = user.password();
+        Set<GrantedAuthority> authorities = new HashSet<>();
+        for (String authority : user.authorities()) {
+            authorities.add(new SimpleGrantedAuthority(authority));
+        }
+
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        SmartCosmosUser principal = new SmartCosmosUser(tenantUrn, userUrn, username, password, authorities);
+        Authentication auth = new UsernamePasswordAuthenticationToken(principal, "password", principal.getAuthorities());
+        context.setAuthentication(auth);
+
+        return context;
+    }
+}

--- a/smartcosmos-framework-test/src/test/java/net/smartcosmos/test/security/WithMockSmartCosmosUserSecurityContextFactoryTest.java
+++ b/smartcosmos-framework-test/src/test/java/net/smartcosmos/test/security/WithMockSmartCosmosUserSecurityContextFactoryTest.java
@@ -1,0 +1,92 @@
+package net.smartcosmos.test.security;
+
+import org.junit.*;
+import org.junit.runner.*;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.annotation.SecurityTestExecutionListeners;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import net.smartcosmos.security.user.SmartCosmosUser;
+
+import static org.junit.Assert.*;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SecurityTestExecutionListeners
+public class WithMockSmartCosmosUserSecurityContextFactoryTest {
+
+    private SecurityContext securityContext;
+    private Authentication authentication;
+    private SmartCosmosUser user;
+
+    @Before
+    public void setUp() {
+        securityContext = SecurityContextHolder.getContext();
+        authentication = securityContext.getAuthentication();
+        user = (SmartCosmosUser) authentication.getPrincipal();
+    }
+
+    @Test
+    @WithMockSmartCosmosUser
+    public void thatPrincipalIsSmartCosmosUser() {
+        Object principal = authentication.getPrincipal();
+
+        assertNotNull(principal);
+        assertTrue(principal instanceof SmartCosmosUser);
+    }
+
+    @Test
+    @WithMockSmartCosmosUser
+    public void thatDefaultValuesAreSet() {
+
+        assertTrue(user.getAuthorities().isEmpty());
+        assertEquals("user", user.getUsername());
+        assertEquals("password", user.getPassword());
+        assertEquals("urn:user:uuid:e2174814-eb6d-4176-978c-58390105375b", user.getUserUrn());
+        assertEquals("urn:tenant:uuid:b5b52af3-9909-4ea4-97bf-07639d683c95", user.getAccountUrn());
+    }
+
+    @Test
+    @WithMockSmartCosmosUser(username = "myNewUser")
+    public void thatUserNameCanBeSet() {
+
+        assertEquals("myNewUser", user.getUsername());
+    }
+
+    @Test
+    @WithMockSmartCosmosUser(password = "xyz123")
+    public void thatPasswordCanBeSet() {
+
+        assertEquals("xyz123", user.getPassword());
+    }
+
+    @Test
+    @WithMockSmartCosmosUser(usernUrn = "urn:user:new")
+    public void thatUserUrnCanBeSet() {
+
+        assertEquals("urn:user:new", user.getUserUrn());
+    }
+
+    @Test
+    @WithMockSmartCosmosUser(tenantUrn = "urn:tenant:new")
+    public void thatTenantUrnCanBeSet() {
+
+        assertEquals("urn:tenant:new", user.getAccountUrn());
+    }
+
+    @Test
+    @WithMockSmartCosmosUser(authorities = { "authority1", "authority2"} )
+    public void thatAuthoritiesCanBeSet() {
+
+        final GrantedAuthority authority1 = new SimpleGrantedAuthority("authority1");
+        final GrantedAuthority authority2 = new SimpleGrantedAuthority("authority2");
+
+        assertFalse(user.getAuthorities().isEmpty());
+        assertEquals(2, user.getAuthorities().size());
+        assertTrue(user.getAuthorities().contains(authority1));
+        assertTrue(user.getAuthorities().contains(authority2));
+    }
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds the previous `smartcosmos-test` artifact to framework as a module, see [smartcosmos-test](https://github.com/SMARTRACTECHNOLOGY/smartcosmos-test).
This change was demanded by Robert yesterday [via Slack](https://smartrac.slack.com/archives/platform/p1469639044000064).

The other repository will be deleted.
### How is this patch documented?
- Javadoc
- README
### How was this patch tested?

Unit tests
#### Depends On

Nothing.
