### PR TITLE
Add the annotation that got lost when the old PR was closed

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/security/authentication/OAuth2SsoRdaoConfiguration.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/security/authentication/OAuth2SsoRdaoConfiguration.java
@@ -1,25 +1,31 @@
 package net.smartcosmos.security.authentication;
 
 import lombok.extern.slf4j.Slf4j;
-import net.smartcosmos.security.authentication.direct.DirectAccessDeniedHandler;
-import net.smartcosmos.security.authentication.direct.DirectUnauthorizedEntryPoint;
-import net.smartcosmos.security.authentication.direct.EnableDirectHandlers;
-import net.smartcosmos.test.security.SmartCosmosTestProperties;
-import net.smartcosmos.test.security.TestUserDetailsService;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.*;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.encoding.PlaintextPasswordEncoder;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
+
+import net.smartcosmos.security.authentication.direct.DirectAccessDeniedHandler;
+import net.smartcosmos.security.authentication.direct.DirectUnauthorizedEntryPoint;
+import net.smartcosmos.security.authentication.direct.EnableDirectHandlers;
+import net.smartcosmos.test.security.SmartCosmosTestProperties;
+import net.smartcosmos.test.security.TestUserDetailsService;
 
 /**
  * @author voor
@@ -28,6 +34,7 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.E
 @Configuration
 @Slf4j
 @ComponentScan
+@EnableGlobalMethodSecurity(prePostEnabled = true)
 public class OAuth2SsoRdaoConfiguration {
 
     @Bean


### PR DESCRIPTION
### What changes were proposed in this pull request?

This adds the configuration annotation required to make `@PreAuthorize` work.

Since it is added on the framework level, the RDAOs don't need to change. The only annotation they need will remain `@EnableSmartCosmosSecurity`.

_This change was the original change in https://github.com/SMARTRACTECHNOLOGY/smartcosmos-framework/pull/179, but got lost when the pull request was closed because of the testing stuff in the wrong location._

### How is this patch documented?

Code.

### How was this patch tested?

RDAO unit tests and manually in Postman.

#### Depends On

Nothing.

