### PR TITLE
Adds in test dependency rather than hard-coded junit dep.

### DIFF
--- a/smartcosmos-framework-test/pom.xml
+++ b/smartcosmos-framework-test/pom.xml
@@ -24,10 +24,8 @@
             <artifactId>spring-security-test</artifactId>
         </dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.12</version>
-            <scope>test</scope>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
         </dependency>
     </dependencies>
 

--- a/smartcosmos-framework-test/pom.xml
+++ b/smartcosmos-framework-test/pom.xml
@@ -20,12 +20,12 @@
             <artifactId>smartcosmos-framework</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.springframework.security</groupId>
-            <artifactId>spring-security-test</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

Adds in Spring test as a full-blown dependency, so we only need to include smartcosmos-framework-test as follows:

```
        <dependency>
            <groupId>net.smartcosmos</groupId>
            <artifactId>smartcosmos-framework-test</artifactId>
            <scope>test</scope>
        </dependency>
```

And you get "the rest" for free.
### How is this patch documented?

In the pom file.
### How was this patch tested?

It's for a test library, hur hur. :hankey: 
