### PR TITLE
Temporarily remove async for sending events.

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/events/rest/RestSmartCosmosEventTemplate.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/events/rest/RestSmartCosmosEventTemplate.java
@@ -62,10 +62,13 @@ public class RestSmartCosmosEventTemplate extends AbstractSmartCosmosEventTempla
         eventHttpHeaders.set("Authorization", String.format("%s %s", tokenType, accessToken.getValue()));
 
         try {
-            smartCosmosEventTaskExecutor.execute(() -> restOperations.exchange(eventUri,
-                                                                               eventHttpMethod,
-                                                                               new HttpEntity<>(message, eventHttpHeaders),
-                                                                               Void.class));
+            // smartCosmosEventTaskExecutor.execute(() -> );
+
+            // Initially, just send the event on the same thread.  Later versions will improve this process to be truly async.
+            restOperations.exchange(eventUri,
+                                    eventHttpMethod,
+                                    new HttpEntity<>(message, eventHttpHeaders),
+                                    Void.class);
         } catch (Exception e) {
             log.trace(e.getMessage(), e);
             throw new SmartCosmosEventException(


### PR DESCRIPTION
In order to not have this be a roadblock to release, temporarily send events on the same thread as the request.
