### PR TITLE
Bugfix/objects 962 async events

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosBootstrapConfiguration.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosBootstrapConfiguration.java
@@ -118,6 +118,8 @@ return new SendsSmartCosmosEventAdvice(smartCosmosEventTemplate);
 
         @Bean
         public RequestContextFilter requestContextFilter() {
+
+            // Add request context filter to bind the request context to the threads and enable thread context inheritance
             RequestContextFilter contextFilter = new RequestContextFilter();
             contextFilter.setThreadContextInheritable(true);
             return contextFilter;
@@ -126,10 +128,14 @@ return new SendsSmartCosmosEventAdvice(smartCosmosEventTemplate);
         @Bean
         @Autowired
         public DispatcherServlet dispatcherServlet(WebMvcProperties webMvcProperties) {
+            
+            // Copy of DispatcherServlet Auto Configuration:
             DispatcherServlet dispatcherServlet = new DispatcherServlet();
             dispatcherServlet.setDispatchOptionsRequest(webMvcProperties.isDispatchOptionsRequest());
             dispatcherServlet.setDispatchTraceRequest(webMvcProperties.isDispatchTraceRequest());
             dispatcherServlet.setThrowExceptionIfNoHandlerFound(webMvcProperties.isThrowExceptionIfNoHandlerFound());
+
+            // Enable thread context inheritance to be able to access the request context in new threads
             dispatcherServlet.setThreadContextInheritable(true);
 
             return dispatcherServlet;

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/events/rest/RestSmartCosmosEventTemplate.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/events/rest/RestSmartCosmosEventTemplate.java
@@ -3,6 +3,8 @@ package net.smartcosmos.events.rest;
 import java.net.URI;
 import java.util.concurrent.Executor;
 
+import lombok.extern.slf4j.Slf4j;
+
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -14,8 +16,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestOperations;
 import org.springframework.web.context.request.RequestAttributes;
 import org.springframework.web.context.request.RequestContextHolder;
-
-import lombok.extern.slf4j.Slf4j;
 
 import net.smartcosmos.events.AbstractSmartCosmosEventTemplate;
 import net.smartcosmos.events.SmartCosmosEvent;
@@ -37,7 +37,7 @@ public class RestSmartCosmosEventTemplate extends AbstractSmartCosmosEventTempla
 
     public RestSmartCosmosEventTemplate(
         RestOperations restOperations,
-            String eventServiceName,
+        String eventServiceName,
         HttpMethod eventHttpMethod,
         String eventUrl,
         Executor smartCosmosEventTaskExecutor) {

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/events/rest/RestSmartCosmosEventTemplate.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/events/rest/RestSmartCosmosEventTemplate.java
@@ -62,13 +62,10 @@ public class RestSmartCosmosEventTemplate extends AbstractSmartCosmosEventTempla
         eventHttpHeaders.set("Authorization", String.format("%s %s", tokenType, accessToken.getValue()));
 
         try {
-            // smartCosmosEventTaskExecutor.execute(() -> );
-
-            // Initially, just send the event on the same thread.  Later versions will improve this process to be truly async.
-            restOperations.exchange(eventUri,
-                                    eventHttpMethod,
-                                    new HttpEntity<>(message, eventHttpHeaders),
-                                    Void.class);
+            smartCosmosEventTaskExecutor.execute(() -> restOperations.exchange(eventUri,
+                                                                               eventHttpMethod,
+                                                                               new HttpEntity<>(message, eventHttpHeaders),
+                                                                               Void.class));
         } catch (Exception e) {
             log.trace(e.getMessage(), e);
             throw new SmartCosmosEventException(


### PR DESCRIPTION
### What changes were proposed in this pull request?
- overrides the `DispatcherServlet` to enable thread inheritance.
- adds a `RequestContextFilter` to bind the request context to threads and enable inheritance
- changes the `RestSmartCosmosEventTemplate` to get the OAuth2 token from the request context attributes instead of the initial `OAuth2ClientContext`
### How is this patch documented?

Code.
### How was this patch tested?

Manually in Postman.
#### Depends On

Nothing.
