### PR TITLE
Bugfix/context in threads

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -1,0 +1,15 @@
+= SMART COSMOS Framework Release Notes
+
+== UNRELEASED
+
+=== New Features
+
+No new features are added in this release.
+
+=== Bugfixes & Improvements
+
+* OBJECTS-995 Thread context inheritance causes side effects with thread pools
+
+== Release 3.0.0 (August 12, 2016)
+
+Initial release.

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosBootstrapConfiguration.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosBootstrapConfiguration.java
@@ -23,7 +23,6 @@ import org.springframework.format.FormatterRegistry;
 import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.filter.RequestContextFilter;
 import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
@@ -117,18 +116,9 @@ return new SendsSmartCosmosEventAdvice(smartCosmosEventTemplate);
     protected static class ThreadInheritanceConfiguration extends WebMvcAutoConfiguration.WebMvcAutoConfigurationAdapter {
 
         @Bean
-        public RequestContextFilter requestContextFilter() {
-
-            // Add request context filter to bind the request context to the threads and enable thread context inheritance
-            RequestContextFilter contextFilter = new RequestContextFilter();
-            contextFilter.setThreadContextInheritable(true);
-            return contextFilter;
-        }
-
-        @Bean
         @Autowired
         public DispatcherServlet dispatcherServlet(WebMvcProperties webMvcProperties) {
-            
+
             // Copy of DispatcherServlet Auto Configuration:
             DispatcherServlet dispatcherServlet = new DispatcherServlet();
             dispatcherServlet.setDispatchOptionsRequest(webMvcProperties.isDispatchOptionsRequest());

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosBootstrapConfiguration.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosBootstrapConfiguration.java
@@ -10,8 +10,6 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
-import org.springframework.boot.autoconfigure.web.WebMvcAutoConfiguration;
-import org.springframework.boot.autoconfigure.web.WebMvcProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.cloud.netflix.ribbon.RibbonClientHttpRequestFactory;
 import org.springframework.context.annotation.Bean;
@@ -23,7 +21,6 @@ import org.springframework.format.FormatterRegistry;
 import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.client.RestTemplate;
-import org.springframework.web.servlet.DispatcherServlet;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
 
 import net.smartcosmos.concurrent.DelegatingSecurityContextAndRequestAttributesExecutorService;
@@ -38,15 +35,16 @@ import net.smartcosmos.events.test.TestSmartCosmosEventRestTemplate;
 @Configuration
 public class SmartCosmosBootstrapConfiguration {
 
-
     @Configuration
     @ConditionalOnBean(FormatterRegistrar.class)
     static class FormatterRegistrarConfiguration extends WebMvcConfigurerAdapter {
+
         @Autowired(required = false)
         Map<String, FormatterRegistrar> formatterRegistrarMap;
 
         @Override
         public void addFormatters(FormatterRegistry registry) {
+
             if (formatterRegistrarMap != null) {
                 for (FormatterRegistrar registrar : formatterRegistrarMap.values()) {
                     registrar.registerFormatters(registry);
@@ -58,12 +56,14 @@ public class SmartCosmosBootstrapConfiguration {
     @Bean
     @Role(BeanDefinition.ROLE_INFRASTRUCTURE)
     public SendsSmartCosmosEventAnnotationBeanPostProcessor sendsSmartCosmosEventAnnotationBeanPostProcessor() {
+
         return new SendsSmartCosmosEventAnnotationBeanPostProcessor();
     }
 
     @Bean
     public SendsSmartCosmosEventAdvice sendsSmartCosmosEventAdvice(SmartCosmosEventTemplate smartCosmosEventTemplate) {
-return new SendsSmartCosmosEventAdvice(smartCosmosEventTemplate);
+
+        return new SendsSmartCosmosEventAdvice(smartCosmosEventTemplate);
     }
 
     @Configuration
@@ -81,8 +81,10 @@ return new SendsSmartCosmosEventAdvice(smartCosmosEventTemplate);
         @Bean
         @Autowired
         @Profile("!test")
-        SmartCosmosEventTemplate smartCosmosEventTemplate(RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory,
-                Executor smartCosmosEventTaskExecutor) {
+        SmartCosmosEventTemplate smartCosmosEventTemplate(
+            RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory,
+            Executor smartCosmosEventTaskExecutor) {
+
             RestTemplate eventRestTemplate = new RestTemplate();
             eventRestTemplate.setRequestFactory(ribbonClientHttpRequestFactory);
             return new RestSmartCosmosEventTemplate(eventRestTemplate,
@@ -95,6 +97,7 @@ return new SendsSmartCosmosEventAdvice(smartCosmosEventTemplate);
         @Bean
         @Profile("test")
         SmartCosmosEventTemplate SmartCosmosEventRestTemplate() {
+
             return new TestSmartCosmosEventRestTemplate();
         }
     }
@@ -105,30 +108,10 @@ return new SendsSmartCosmosEventAdvice(smartCosmosEventTemplate);
 
         @Bean
         public Executor smartCosmosEventTaskExecutor() {
+
             ExecutorService executorService = Executors.newCachedThreadPool();
             return new DelegatingSecurityContextAndRequestAttributesExecutorService(executorService);
         }
 
-    }
-
-    @Configuration
-    @EnableAsync
-    protected static class ThreadInheritanceConfiguration extends WebMvcAutoConfiguration.WebMvcAutoConfigurationAdapter {
-
-        @Bean
-        @Autowired
-        public DispatcherServlet dispatcherServlet(WebMvcProperties webMvcProperties) {
-
-            // Copy of DispatcherServlet Auto Configuration:
-            DispatcherServlet dispatcherServlet = new DispatcherServlet();
-            dispatcherServlet.setDispatchOptionsRequest(webMvcProperties.isDispatchOptionsRequest());
-            dispatcherServlet.setDispatchTraceRequest(webMvcProperties.isDispatchTraceRequest());
-            dispatcherServlet.setThrowExceptionIfNoHandlerFound(webMvcProperties.isThrowExceptionIfNoHandlerFound());
-
-            // Enable thread context inheritance to be able to access the request context in new threads
-            dispatcherServlet.setThreadContextInheritable(true);
-
-            return dispatcherServlet;
-        }
     }
 }

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosBootstrapConfiguration.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosBootstrapConfiguration.java
@@ -18,7 +18,6 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.context.annotation.Role;
 import org.springframework.format.FormatterRegistrar;
 import org.springframework.format.FormatterRegistry;
-import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
@@ -104,7 +103,7 @@ public class SmartCosmosBootstrapConfiguration {
 
     @Configuration
     @EnableAsync
-    protected static class AsyncConfig extends AsyncConfigurerSupport {
+    protected static class AsyncConfig {
 
         @Bean
         public Executor smartCosmosEventTaskExecutor() {

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/events/rest/RestSmartCosmosEventTemplate.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/events/rest/RestSmartCosmosEventTemplate.java
@@ -5,6 +5,7 @@ import java.util.concurrent.Executor;
 
 import lombok.extern.slf4j.Slf4j;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -35,6 +36,7 @@ public class RestSmartCosmosEventTemplate extends AbstractSmartCosmosEventTempla
 
     private final Executor smartCosmosEventTaskExecutor;
 
+    @Autowired
     public RestSmartCosmosEventTemplate(
         RestOperations restOperations,
         String eventServiceName,


### PR DESCRIPTION
### What changes were proposed in this pull request?

This change removes the `RequestContextFilter` and `DispatcherServlet` that called `setThreadContextInheritable(true);` due to possible side effects when using thread pools.

**Important:**

When this pull request is merged, core/local services that depend on the new Framework version may not use asynchronous processing anymore.
If they really have to create new threads from which they need access to the parent thread context, they either need to get the required information before creation of the new thread, or they have to enable context inheritance and **must not** use thread pools in this case.
### How is this patch documented?

Code.
### How was this patch tested?

manually in Postman.
#### Depends On

Nothing.
