### PR TITLE
Improves testing to use an OAuth2 request

### DIFF
--- a/smartcosmos-framework-test/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUser.java
+++ b/smartcosmos-framework-test/src/main/java/net/smartcosmos/test/security/WithMockSmartCosmosUser.java
@@ -49,4 +49,8 @@ public @interface WithMockSmartCosmosUser {
      * @return the mock user authorities
      */
     String[] authorities() default {};
+
+    String[] scopes() default {};
+
+    String clientId() default "smartcosmosservice";
 }

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/security/authentication/OAuth2SsoRdaoConfiguration.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/security/authentication/OAuth2SsoRdaoConfiguration.java
@@ -4,29 +4,19 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Primary;
-import org.springframework.context.annotation.Profile;
 import org.springframework.core.annotation.Order;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.encoding.PlaintextPasswordEncoder;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
-import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
+import org.springframework.core.env.Environment;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
+import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
 
 import net.smartcosmos.security.authentication.direct.DirectAccessDeniedHandler;
 import net.smartcosmos.security.authentication.direct.DirectUnauthorizedEntryPoint;
 import net.smartcosmos.security.authentication.direct.EnableDirectHandlers;
-import net.smartcosmos.test.security.SmartCosmosTestProperties;
-import net.smartcosmos.test.security.TestUserDetailsService;
 
 /**
  * @author voor
@@ -38,20 +28,23 @@ import net.smartcosmos.test.security.TestUserDetailsService;
 @EnableGlobalMethodSecurity(prePostEnabled = true)
 public class OAuth2SsoRdaoConfiguration {
 
-    @Bean
-    @Primary
-    public AuthenticationManager authenticationManager(
-            AuthenticationConfiguration configuration) throws Exception {
-        return configuration.getAuthenticationManager();
-    }
-
     @Order(SecurityProperties.ACCESS_OVERRIDE_ORDER - 1)
     @EnableDirectHandlers
     @EnableResourceServer
     @Configuration
-    @Profile({ "!test" })
     protected static class OAuth2SsoConfigurerAdapter
         extends ResourceServerConfigurerAdapter {
+
+        @Autowired
+        private Environment environment;
+
+        @Override
+        public void configure(ResourceServerSecurityConfigurer resources) throws Exception {
+
+            // This is necessary since it'll clear the context removing the mock user otherwise.
+            // see https://stackoverflow.com/questions/37573361/springsecurity-withsecuritycontext-mockmvc-oauth2-always-unauthorised
+            resources.stateless(!environment.acceptsProfiles("test"));
+        }
 
         @Override
         public void configure(HttpSecurity http) throws Exception {
@@ -60,36 +53,6 @@ public class OAuth2SsoRdaoConfiguration {
             http.exceptionHandling().accessDeniedHandler(new DirectAccessDeniedHandler())
                     .authenticationEntryPoint(new DirectUnauthorizedEntryPoint("/login")).and()
                     .antMatcher("/**").authorizeRequests().anyRequest().authenticated();
-        }
-    }
-
-    @Order(SecurityProperties.ACCESS_OVERRIDE_ORDER)
-    @EnableDirectHandlers
-    @Configuration
-    @Profile({ "test" })
-    @EnableConfigurationProperties({ SmartCosmosTestProperties.class })
-    protected static class TestOAuth2SsoConfigurerAdapter
-            extends WebSecurityConfigurerAdapter {
-
-        @Autowired
-        SmartCosmosTestProperties smartCosmosTestProperties;
-
-        @Bean
-        public UserDetailsService userDetailsService() {
-            return new TestUserDetailsService(smartCosmosTestProperties.getUsers());
-        }
-
-        protected void configure(HttpSecurity http) throws Exception {
-            http.csrf().disable().authorizeRequests().anyRequest().authenticated().and()
-                    .httpBasic();
-        }
-
-        @Override
-        protected void configure(AuthenticationManagerBuilder auth) throws Exception {
-            log.warn(
-                    "Test Smart Cosmos Security enabled, all requests should be made as user:password@ for testing.");
-            auth.userDetailsService(userDetailsService())
-                    .passwordEncoder(new PlaintextPasswordEncoder());
         }
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
- Allows the `@WithMockSmartCosmosUser` to have scopes and a client id.
- Changes `OAuth2SsoRdaoConfiguration` to fully remove the test security context (was causing problems) and has test environments as stateFUL to resolve issue found at https://stackoverflow.com/questions/37573361/springsecurity-withsecuritycontext-mockmvc-oauth2-always-unauthorised
### How is this patch documented?

In comments
### How was this patch tested?

Propagated down to dependencies using the new version of the framework.
