### PR TITLE
PROFILES-699: Change SmartCosmosException to be a RuntimeException

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/aspects/SmartCosmosServiceAspect.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/aspects/SmartCosmosServiceAspect.java
@@ -23,7 +23,7 @@ import net.smartcosmos.exceptions.SmartCosmosException;
  */
 @Aspect
 @Component
-public class SmartCosmosExtensionAspects {
+public class SmartCosmosServiceAspect {
 
     @Pointcut("@annotation(net.smartcosmos.annotation.SmartCosmosService) || @within(net.smartcosmos.annotation.SmartCosmosService)")
     public void hasSmartCosmosServiceAnnotation() {}

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/aspects/SmartCosmosServiceAspect.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/aspects/SmartCosmosServiceAspect.java
@@ -11,14 +11,17 @@ import org.springframework.stereotype.Component;
 import net.smartcosmos.exceptions.SmartCosmosException;
 
 /**
- * Aspects to be applied to extension services implemented in the SMART COSMOS Objects architecture.
+ * Aspect to be applied to extension services implemented in the SMART COSMOS Objects architecture.
  * <p>
- * To use this aspect you will need to enable aspects with @EnableAspectJAutoProxy in your @Configuration.  Then you need to add
- * the @SmartCosmosService annotation to the service classes you with to apply the aspect to.
+ * Using this aspect will capture all exceptions and convert them into a {@see SmartCosmosException}.  If your methods do not declare
+ * they throw SmartCosmosException then you will receive an {@see UndeclaredThrowableException}
  * </p>
  * <p>
- * Using this aspect will capture all exceptions and conver them into a {@see SmartCosmosException}.  If your methods do not declare
- * they throw SmartCosmosException then you will receive an UndeclaredThrowableException
+ * To use this aspect add the @SmartCosmosService annotation to the service class(es).  If you have interfaces with default methods
+ * This annotation will need to be applied to the interface.
+ * </p>
+ * <p>For this aspect to be enabled you will need to enable aspects with @EnableAspectJAutoProxy in your @Configuration.  Spring Boot will
+ * auto-configure this in most situations since at least 1.3.2.
  * </p>
  */
 @Aspect

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/aspects/SmartCosmosServiceAspect.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/aspects/SmartCosmosServiceAspect.java
@@ -46,7 +46,7 @@ public class SmartCosmosServiceAspect {
         }
 
         String msg = String.format("Error in service: '%s', cause: '%s', method: '%s', arguments: '%s'",
-                                   jp.getTarget(), t.toString(), jp.getSignature().toLongString(), StringUtils.join(jp.getArgs(), " , "));
+                                   jp.getTarget().toString(), t.toString(), jp.getSignature().toLongString(), StringUtils.join(jp.getArgs(), " , "));
         Logger.getLogger(jp.getClass()).error(msg);
         Logger.getLogger(jp.getClass()).debug(msg, t);
         throw new SmartCosmosException(msg, t);

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/exceptions/SmartCosmosException.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/exceptions/SmartCosmosException.java
@@ -3,9 +3,9 @@ package net.smartcosmos.exceptions;
 /**
  * Generic base exception for the SMART COSMOS Objects platform.
  */
-public class SmartCosmosException extends Exception {
+public class SmartCosmosException extends RuntimeException {
 
-    private static final long serialVersionUID = -4863318680106697788L;
+    private static final long serialVersionUID = 8059819376742981420L;
 
     /**
      * Default Exception constructor.

--- a/smartcosmos-framework/src/test/java/net/smartcosmos/aspects/SmartCosmosServiceAspectTest.java
+++ b/smartcosmos-framework/src/test/java/net/smartcosmos/aspects/SmartCosmosServiceAspectTest.java
@@ -18,7 +18,7 @@ import net.smartcosmos.exceptions.SmartCosmosException;
 @RunWith(SpringJUnit4ClassRunner.class)
 @ActiveProfiles("test")
 @SpringApplicationConfiguration(classes = { LocalAopTestContextConfig.class })
-public class SmartCosmosExtensionAspectsTest {
+public class SmartCosmosServiceAspectTest {
 
     @Rule
     public ExpectedException thrown = ExpectedException.none();


### PR DESCRIPTION
### What changes were proposed in this pull request?

Changes the new `SmartCosmosException` to inherit from `RuntimeException` rather than `Exception`.  This will allow us to more easily remain consistent with the current Objects API declarations.

### How is this patch documented?

The aspects and the exception class.

### How was this patch tested?

Unit tests and Postman 

#### Depends On

Nothing