### PR TITLE
prevent the password hash erase implemented in the base class

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/security/user/SmartCosmosCachedUser.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/security/user/SmartCosmosCachedUser.java
@@ -23,6 +23,11 @@ public class SmartCosmosCachedUser extends SmartCosmosUser {
         super(accountUrn, userUrn, username, password, authorities);
     }
 
+    @Override
+    public void eraseCredentials() {
+        // do nothing here, just prevent the password hash erase implemented in the base class
+    }
+
     public Date getCachedDate() {
         return this.cachedDate;
     }


### PR DESCRIPTION
### What changes were proposed in this pull request?

* this fixes prevents erasing password hashes from cached user objects
* without the fix, the **SmartCosmosCachedUser** objects are effectively unusable for the auth server

#### Note

* the fix does not change the cache timeouts, that is a separate story in OBJECTS-1053

### How is this patch documented?

**SmartCosmosCachedUser** is based on **org.springframework.security.core.userdetails.User**
In the base implementation Spring calls eraseCredentials after a succesful authentication, which makes the **SmartCosmosCachedUser** object worthless.

### How was this patch tested?

* Tested with auth-server in Postman.
* The unit test for this needs to be done in auth server.

#### Depends On

None.

