### PR TITLE
cached user timeout pushed to auth-server config smartcosmos.security…

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/security/SecurityResourceProperties.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/security/SecurityResourceProperties.java
@@ -15,11 +15,14 @@ import org.springframework.core.io.Resource;
 @ConfigurationProperties("smartcosmos.security.resource")
 public class SecurityResourceProperties {
 
+    public static final int DEFAULT_CACHED_USER_KEEP_ALIVE_SECS = 300;
+
     private KeyStoreProperties keystore = new KeyStoreProperties();
     private UserDetailsProperties userDetails = new UserDetailsProperties();
 
     private String clientId;
     private String clientSecret;
+    private Integer cachedUserKeepAliveSecs = DEFAULT_CACHED_USER_KEEP_ALIVE_SECS;
 
     @Data
     public class KeyStoreProperties {

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/security/user/SmartCosmosCachedUser.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/security/user/SmartCosmosCachedUser.java
@@ -14,9 +14,8 @@ import org.springframework.security.core.GrantedAuthority;
  */
 public class SmartCosmosCachedUser extends SmartCosmosUser {
 
-    // TODO Caching time is hardcoded at 5 minutes, should change this.
-    private final Date cachedDate = new Date(
-            System.currentTimeMillis() + TimeUnit.MINUTES.toMillis(5));
+    // Caching time is set in auth server config smartcosmos.security.cachedUserKeepAliveSecs
+    private final Date cachedDate = new Date(System.currentTimeMillis());
 
     public SmartCosmosCachedUser(String accountUrn, String userUrn, String username,
             String password, Collection<? extends GrantedAuthority> authorities) {

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/security/user/SmartCosmosCachedUser.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/security/user/SmartCosmosCachedUser.java
@@ -14,7 +14,7 @@ import org.springframework.security.core.GrantedAuthority;
  */
 public class SmartCosmosCachedUser extends SmartCosmosUser {
 
-    // Caching time is set in auth server config smartcosmos.security.cachedUserKeepAliveSecs
+    // Caching time is set in auth server config smartcosmos.security.resource.cachedUserKeepAliveSecs
     private final Date cachedDate = new Date(System.currentTimeMillis());
 
     public SmartCosmosCachedUser(String accountUrn, String userUrn, String username,


### PR DESCRIPTION
### What changes were proposed in this pull request?

Moves cached user timeout to auth server configuration element 
smartcosmos.security.resource.cachedUserKeepAliveSecs: 300

Default is 300, as it was hardcoded before in SmartCosmosCachedUser.java
### How is this patch documented?

Source, auth-server config
### How was this patch tested?

Debugger, postman
#### Depends On

Nothing. Will default to 300 if value not set in auth server config.
