### PR TITLE
extend SmartCosmosEventException from SmartCosmosException

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/events/SmartCosmosEventException.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/events/SmartCosmosEventException.java
@@ -1,9 +1,11 @@
 package net.smartcosmos.events;
 
+import net.smartcosmos.exceptions.SmartCosmosException;
+
 /**
- * @author voor
+ * Event handler exception for the SMART COSMOS Objects platform, based on {@see SmartCosmosException}.
  */
-public class SmartCosmosEventException extends Exception {
+public class SmartCosmosEventException extends SmartCosmosException {
     public SmartCosmosEventException(String message, Throwable cause) {
         super(message, cause);
     }

--- a/smartcosmos-framework/src/test/java/net/smartcosmos/aspects/SmartCosmosServiceAspectTest.java
+++ b/smartcosmos-framework/src/test/java/net/smartcosmos/aspects/SmartCosmosServiceAspectTest.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 import net.smartcosmos.annotation.SmartCosmosService;
+import net.smartcosmos.events.SmartCosmosEventException;
 import net.smartcosmos.exceptions.SmartCosmosException;
 
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -48,6 +49,13 @@ public class SmartCosmosServiceAspectTest {
     }
 
     @Test
+    public void capturesSmartCosmosEventException() throws Exception {
+
+        thrown.expect(SmartCosmosException.class);
+        testService.testWithSmartCosmosEventException();
+    }
+
+    @Test
     public void capturesThrowable() throws Throwable {
 
         thrown.expect(SmartCosmosException.class);
@@ -78,6 +86,8 @@ interface SmartCosmosAopTestService {
 
     void testWithSmartCosmosException() throws Exception;
 
+    void testWithSmartCosmosEventException() throws Exception;
+
     void testWithThrowable() throws Throwable;
 
     default void testDefaultMethodWithException() throws Throwable {
@@ -104,6 +114,12 @@ class SmartCosmosAopTestServiceDefault implements SmartCosmosAopTestService {
     public void testWithSmartCosmosException() throws SmartCosmosException {
 
         throw new SmartCosmosException("This is a SmartCosmosException.");
+    }
+
+    public void testWithSmartCosmosEventException() throws SmartCosmosException {
+
+        Exception cause = new Exception("This is an exception");
+        throw new SmartCosmosEventException("This is a SmartCosmosEventException.", cause);
     }
 
     public void testWithThrowable() throws Throwable {


### PR DESCRIPTION
### What changes were proposed in this pull request?

* extend SmartCosmosEventException from SmartCosmosException

### How is this patch documented?

This change allows to simplify exception handling of the event services.

Before:
```
    @Override
    public void sendEvent(SmartCosmosUser user, String eventType, Object entity) {

        try {
            smartCosmosEventTemplate.sendEvent(entity, eventType, user);
        } catch (SmartCosmosEventException e) {
            String msg = String.format("Exception processing relationship event '%s', entity: '%s', cause: '%s'.", eventType, entity, e.toString());
            log.error(msg);
            log.debug(msg, e);
        }
    }
```
After:
```
    @Override
    public void sendEvent(SmartCosmosUser user, String eventType, Object entity) {

        smartCosmosEventTemplate.sendEvent(entity, eventType, user);
    }
```
To make this change work, the event sending service needs to be annotated with `@SmartCosmosService` instead of `@Service`. The exception will then be caught and logged by the `SmartCosmosServiceAspect`.

### How was this patch tested?

* JUnit tests updated
* Removed the SmartCosmosEventException event handler for testing in profiles-edge-tagdata

#### Depends On

None.