### PR TITLE
RequestExceptionHandler.java now handling SmartCosmosException

### DIFF
--- a/smartcosmos-framework/src/main/java/net/smartcosmos/exceptions/handlers/RequestExceptionHandler.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/exceptions/handlers/RequestExceptionHandler.java
@@ -30,7 +30,7 @@ import net.smartcosmos.exceptions.SmartCosmosException;
 @Slf4j
 public class RequestExceptionHandler extends ResponseEntityExceptionHandler {
 
-    public static final String DEFAULT_SMART_COSMOS_EXCEPTION_MESSAGE = "Unspecifed SmartCosmosException";
+    public static final String DEFAULT_SMART_COSMOS_EXCEPTION_MESSAGE = "Unspecified SmartCosmosException";
     protected static final int ERR_FAILURE = -1;
     protected static final int ERR_FIELD_CONSTRAINT_VIOLATION = -5;
     protected static final int ERR_VALIDATION_FAILURE = -15;

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/exceptions/handlers/RequestExceptionHandler.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/exceptions/handlers/RequestExceptionHandler.java
@@ -21,6 +21,7 @@ import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import net.smartcosmos.exceptions.NoEntityFoundException;
+import net.smartcosmos.exceptions.SmartCosmosException;
 
 /**
  * Controller advice to translate exceptions occurring on request processing to response entities.
@@ -29,13 +30,49 @@ import net.smartcosmos.exceptions.NoEntityFoundException;
 @Slf4j
 public class RequestExceptionHandler extends ResponseEntityExceptionHandler {
 
-    private static final int ERR_FAILURE = -1;
-    private static final int ERR_FIELD_CONSTRAINT_VIOLATION = -5;
-    private static final int ERR_VALIDATION_FAILURE = -15;
+    public static final String DEFAULT_SMART_COSMOS_EXCEPTION_MESSAGE = "Unspecifed SmartCosmosException";
+    protected static final int ERR_FAILURE = -1;
+    protected static final int ERR_FIELD_CONSTRAINT_VIOLATION = -5;
+    protected static final int ERR_VALIDATION_FAILURE = -15;
 
     private static final String CODE = "code";
     private static final String MESSAGE = "message";
 
+    @ExceptionHandler(SmartCosmosException.class)
+    protected ResponseEntity<?> handleSmartCosmosExceptionMethod(SmartCosmosException exception, WebRequest request) {
+
+        if (exception.getCause() == null) {
+            logException(exception, request);
+            HttpHeaders headers = new HttpHeaders();
+            HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+            return handleExceptionInternal(exception, getErrorResponseBody(ERR_FAILURE, exception.getMessage()), headers, status, request);
+
+
+        }
+        if (exception.getCause() instanceof NoEntityFoundException) {
+            return handleNoEntityFoundRequestHandlingMethod((NoEntityFoundException)exception.getCause(), request);
+        }
+        if (exception.getCause() instanceof ConversionFailedException) {
+            return handleConversionFailure((ConversionFailedException)exception.getCause(), request);
+        }
+        if (exception.getCause() instanceof IllegalArgumentException) {
+            return handleIllegalArgument((IllegalArgumentException)exception.getCause(), request);
+        }
+        if (exception.getCause() instanceof ConstraintViolationException) {
+            return handleConstraintViolation((ConstraintViolationException)exception.getCause(), request);
+        }
+        if (exception.getCause() instanceof MethodArgumentNotValidException) {
+            HttpHeaders headers = new HttpHeaders();
+            HttpStatus status = HttpStatus.BAD_REQUEST;
+            return handleMethodArgumentNotValid((MethodArgumentNotValidException)exception.getCause(), headers, status, request);
+        }
+        HttpHeaders headers = new HttpHeaders();
+        HttpStatus status = HttpStatus.INTERNAL_SERVER_ERROR;
+
+        return handleExceptionInternal(exception, getErrorResponseBody(ERR_FAILURE, exception.toString()), headers, status, request);
+
+
+    }
     /**
      * <p>Customize the response for NoEntityFoundException.</p>
      * <p>This method logs a warning and delegates to {@link #handleExceptionInternal}. A {@code 400 Bad Request} response will be returned.</p>

--- a/smartcosmos-framework/src/test/java/net/smartcosmos/exceptions/handlers/RequestExceptionHandlerTest.java
+++ b/smartcosmos-framework/src/test/java/net/smartcosmos/exceptions/handlers/RequestExceptionHandlerTest.java
@@ -1,0 +1,93 @@
+package net.smartcosmos.exceptions.handlers;
+
+import java.util.HashSet;
+import java.util.IllegalFormatCodePointException;
+import java.util.Map;
+import javax.servlet.http.HttpServletRequest;
+import javax.validation.ConstraintViolationException;
+
+import org.bouncycastle.cert.ocsp.Req;
+import org.junit.*;
+import org.mockito.*;
+import org.springframework.core.convert.ConversionFailedException;
+import org.springframework.core.convert.TypeDescriptor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.handler.DispatcherServletWebRequest;
+
+import net.smartcosmos.exceptions.NoEntityFoundException;
+import net.smartcosmos.exceptions.SmartCosmosException;
+import net.smartcosmos.exceptions.handlers.RequestExceptionHandler;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Initially created by SMART COSMOS Team on October 21, 2016.
+ */
+public class RequestExceptionHandlerTest {
+
+    HttpServletRequest request = mock(HttpServletRequest.class);
+    WebRequest webRequest = new DispatcherServletWebRequest(request);
+    RequestExceptionHandler handler =  spy(new RequestExceptionHandler());
+
+    @Test
+    public void thatSmartCosmosExceptionWithNoCauseReturnsErrFailureResponseBody() {
+
+        SmartCosmosException smartCosmosException = new SmartCosmosException("just message, no cause");
+        ResponseEntity responseEntity = handler.handleSmartCosmosExceptionMethod(smartCosmosException, webRequest);
+        assertEquals(responseEntity.getStatusCode(), HttpStatus.INTERNAL_SERVER_ERROR);
+        assertEquals(((Map<String, String>)responseEntity.getBody()).get("message"), "just message, no cause");
+    }
+
+    @Test
+    public void thatSmartCosmosExceptionWithCauseNoEntityFoundReturnsAppropriateResponseBody() {
+
+        NoEntityFoundException entityNotFoundException = new NoEntityFoundException("cause no entity found");
+        SmartCosmosException smartCosmosException = new SmartCosmosException("caused by EntityNotFoundException", entityNotFoundException);
+        ResponseEntity responseEntity = handler.handleSmartCosmosExceptionMethod(smartCosmosException, webRequest);
+        assertEquals(responseEntity.getStatusCode(), HttpStatus.BAD_REQUEST);
+        assertEquals(((Map<String, String>)responseEntity.getBody()).get("message"), "cause no entity found");
+        verify(handler, times(1)).handleNoEntityFoundRequestHandlingMethod(eq(entityNotFoundException), eq(webRequest));
+    }
+
+    @Test
+    @Ignore // TODO figure out how to construct a no-op ConversionFailedException
+    public void thatSmartCosmosExceptionWithCauseConversionFailedReturnsAppropriateResponseBody() {
+        ConversionFailedException conversionFailedException = new ConversionFailedException(TypeDescriptor.forObject(new String()), TypeDescriptor.forObject(new String()), new String("whatever"), new RuntimeException());
+        SmartCosmosException smartCosmosException = new SmartCosmosException("caused by ConversionFailedException", conversionFailedException);
+        ResponseEntity responseEntity = handler.handleSmartCosmosExceptionMethod(smartCosmosException, webRequest);
+        assertEquals(responseEntity.getStatusCode(), HttpStatus.INTERNAL_SERVER_ERROR);
+        assertEquals(((Map<String, String>)responseEntity.getBody()).get("message"), "caused by ConversionFailedException");
+        verify(handler, times(1)).handleConversionFailure(eq(conversionFailedException), eq(webRequest));
+    }
+
+    @Test
+    public void thatSmartCosmosExceptionWithCauseIllegalArgumentReturnsAppropriateResponseBody() {
+
+        IllegalArgumentException illegalArgumentException = new IllegalArgumentException("illegal argument exception");
+        SmartCosmosException smartCosmosException = new SmartCosmosException("caused by IllegalArgumentException", illegalArgumentException);
+        ResponseEntity responseEntity = handler.handleSmartCosmosExceptionMethod(smartCosmosException, webRequest);
+        assertEquals(responseEntity.getStatusCode(), HttpStatus.BAD_REQUEST);
+        assertEquals(((Map<String, String>)responseEntity.getBody()).get("message"), "illegal argument exception");
+        verify(handler, times(1)).handleIllegalArgument(eq(illegalArgumentException), eq(webRequest));
+    }
+
+    @Test
+    public void thatSmartCosmosExceptionWithCauseConstraintViolationReturnsAppropriateResponseBody() {
+
+        ConstraintViolationException constraintViolationException = new ConstraintViolationException("constraint violation exception", new HashSet<>());
+        SmartCosmosException smartCosmosException = new SmartCosmosException("caused by ConstraintViolationException", constraintViolationException);
+        ResponseEntity responseEntity = handler.handleSmartCosmosExceptionMethod(smartCosmosException, webRequest);
+        assertEquals(responseEntity.getStatusCode(), HttpStatus.BAD_REQUEST);
+        assertEquals(((Map<String, String>)responseEntity.getBody()).get("message"), "JSON is missing a required field or violates field constraints: ");
+        verify(handler, times(1)).handleConstraintViolation(eq(constraintViolationException), eq(webRequest));
+    }
+
+
+}


### PR DESCRIPTION
### What changes were proposed in this pull request?

RequestExceptionHandler now deals with SmartCosmosExceptions - when the cause is one of
the already-handled-here exceptions, it calls the appropriate handler, when not it creates and
returns and INTERNAL_SERVER_ERROR response.
### How is this patch documented?

Code.
### How was this patch tested?

Additional unit tests in test/net.smartcosmos.exceptions.handlers.RequestExceptionHandlerTest.java

(Additionally, please make sure to define at least one label.)
#### Depends On

Nothing. Nix. Nada. Bupkis.
