### PR TITLE
Remove Eureka and Ribbon

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -11,6 +11,7 @@
 * OBJECTS-995 Thread context inheritance causes side effects with thread pools
 * OBJECTS-1047 Deprecate `UuidUtil` class
 * Improves testing to use an OAuth2 request instead of a mocked basic request
+* Removes Ribbon and Eureka
 
 == Release 3.0.0 (August 12, 2016)
 

--- a/smartcosmos-framework/pom.xml
+++ b/smartcosmos-framework/pom.xml
@@ -15,6 +15,11 @@
     <description>Provides Spring Configuration and Annotations making it easier to develop SMART COSMOS Extensions</description>
     <dependencies>
         <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>
@@ -39,10 +44,6 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-config</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-eureka</artifactId>
         </dependency>
         <dependency>
             <groupId>org.springframework.cloud</groupId>

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/EnableSmartCosmosEvents.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/EnableSmartCosmosEvents.java
@@ -6,7 +6,6 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.context.annotation.Import;
 
 /**
@@ -17,7 +16,6 @@ import org.springframework.context.annotation.Import;
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
-@EnableDiscoveryClient
 @Documented
 @Import({ SmartCosmosBootstrapConfiguration.class })
 public @interface EnableSmartCosmosEvents {

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosBootstrapConfiguration.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosBootstrapConfiguration.java
@@ -83,9 +83,9 @@ public class SmartCosmosBootstrapConfiguration {
 
             RestTemplate eventRestTemplate = new RestTemplate();
             return new RestSmartCosmosEventTemplate(eventRestTemplate,
-                                                    smartCosmosEventsProperties.getServiceName(),
+                                                    smartCosmosEventsProperties.getAddress(),
                                                     smartCosmosEventsProperties.getHttpMethod(),
-                                                    smartCosmosEventsProperties.getUrl(),
+                                                    smartCosmosEventsProperties.getPath(),
                                                     smartCosmosEventTaskExecutor);
         }
 

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosBootstrapConfiguration.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosBootstrapConfiguration.java
@@ -11,7 +11,6 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.cloud.netflix.ribbon.RibbonClientHttpRequestFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Profile;
@@ -80,12 +79,9 @@ public class SmartCosmosBootstrapConfiguration {
         @Bean
         @Autowired
         @Profile("!test")
-        SmartCosmosEventTemplate smartCosmosEventTemplate(
-            RibbonClientHttpRequestFactory ribbonClientHttpRequestFactory,
-            Executor smartCosmosEventTaskExecutor) {
+        SmartCosmosEventTemplate smartCosmosEventTemplate(Executor smartCosmosEventTaskExecutor) {
 
             RestTemplate eventRestTemplate = new RestTemplate();
-            eventRestTemplate.setRequestFactory(ribbonClientHttpRequestFactory);
             return new RestSmartCosmosEventTemplate(eventRestTemplate,
                                                     smartCosmosEventsProperties.getServiceName(),
                                                     smartCosmosEventsProperties.getHttpMethod(),

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosEventsProperties.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/annotation/SmartCosmosEventsProperties.java
@@ -9,11 +9,11 @@ import org.springframework.http.HttpMethod;
  * @author voor
  */
 @Data
-@ConfigurationProperties("smartcosmos.events")
+@ConfigurationProperties("smartcosmos.service.events")
 public class SmartCosmosEventsProperties {
 
-        private String serviceName = "smartcosmos-events";
-        private String url = "";
-        private HttpMethod httpMethod = HttpMethod.POST;
+    private String address = "http://events";
+    private String path = "";
+    private HttpMethod httpMethod = HttpMethod.POST;
 
 }

--- a/smartcosmos-framework/src/main/java/net/smartcosmos/events/rest/RestSmartCosmosEventTemplate.java
+++ b/smartcosmos-framework/src/main/java/net/smartcosmos/events/rest/RestSmartCosmosEventTemplate.java
@@ -39,13 +39,13 @@ public class RestSmartCosmosEventTemplate extends AbstractSmartCosmosEventTempla
     @Autowired
     public RestSmartCosmosEventTemplate(
         RestOperations restOperations,
-        String eventServiceName,
+        String eventAddress,
         HttpMethod eventHttpMethod,
-        String eventUrl,
+        String eventPath,
         Executor smartCosmosEventTaskExecutor) {
         this.restOperations = restOperations;
         this.eventHttpMethod = eventHttpMethod;
-        this.eventUri = URI.create("http://" + eventServiceName + "/" + eventUrl);
+        this.eventUri = URI.create(eventAddress + "/" + eventPath);
         this.smartCosmosEventTaskExecutor = smartCosmosEventTaskExecutor;
     }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?

This removes Eureka Client and Ribbon, which are not being used outside of a development environment.  Takes out unnecessary dependencies, also identifies areas where we were accidentally introducing mismatched configuration.  See https://github.com/SMARTRACTECHNOLOGY/smartcosmos-cluster-config/pull/21 for the config changes that need to accompany this.
#### Depends On

(circular dependency, teehee)
https://github.com/SMARTRACTECHNOLOGY/smartcosmos-cluster-config/pull/21
