### PR TITLE
kafka version updated to current release 1.1.1.RELEASE

### DIFF
--- a/smartcosmos-dependencies/pom.xml
+++ b/smartcosmos-dependencies/pom.xml
@@ -16,7 +16,7 @@
 
     <properties>
         <smartcosmos-user-details.version>0.0.1-SNAPSHOT</smartcosmos-user-details.version>
-        <spring-kafka.version>1.0.0.RC1</spring-kafka.version>
+        <spring-kafka.version>1.1.1.RELEASE</spring-kafka.version>
     </properties>
     <dependencyManagement>
         <dependencies>
@@ -34,11 +34,6 @@
                 <groupId>com.fasterxml.uuid</groupId>
                 <artifactId>java-uuid-generator</artifactId>
                 <version>3.1.4</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.kafka</groupId>
-                <artifactId>kafka-clients</artifactId>
-                <version>0.9.0.1</version>
             </dependency>
             <dependency>
                 <groupId>org.mapstruct</groupId>


### PR DESCRIPTION
### What changes were proposed in this pull request?
spring-kafka version updated to current 1.1.1.RELEASE, explicit dependency on org.apache.kafka-clients removed

### How is this patch documented?

Changes in framework-dependencies/pom.xml

### How was this patch tested?

Existing tests, plus builds unit tests in other modules run against this version of framework.

#### Depends On

Nothing
